### PR TITLE
WIP: Adjust Event Numbers for Some 2016 Samples

### DIFF
--- a/Framework/cfg/sampleSets_v6.cfg
+++ b/Framework/cfg/sampleSets_v6.cfg
@@ -108,19 +108,19 @@
 2016_TTHH, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTHH_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.000741, 100000, 0, 1.0
 2016_TTTJ, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTTJ_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.000741, 96288, 0, 1.0
 2016_TTTT, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTTT_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8.txt, TreeMaker2/PreSelection, 0.009103, 1739606, 716434, 1.0
-2016_TTTW, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTTW_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.000861, 97232, 0, 1.0
+2016_TTTW, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTTW_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.000861, 97200, 0, 1.0
 2016_TTWH, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTWH_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.001360, 100000, 0, 1.0
 2016_TTWW, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTWW_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.007834, 98300, 0, 1.0
-2016_TTWZ, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTWZ_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.002970, 99142, 0, 1.0
+2016_TTWZ, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTWZ_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.002970, 100000, 0, 1.0
 2016_TTZH, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTZH_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.001250, 97855, 0, 1.0
-2016_TTZZ, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTZZ_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.001570, 98713, 0, 1.0
+2016_TTZZ, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTZZ_TuneCUETP8M2T4_13TeV-madgraph-pythia8.txt, TreeMaker2/PreSelection, 0.001570, 98400, 0, 1.0
 
 # NLO --> negative weights!  
 2016_TTGJets, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt, TreeMaker2/PreSelection, 3.697, 9761650, 4987203, 1.0
 
 # ttH 
-2016_ttHJetTobb, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8.txt, TreeMaker2/PreSelection, 0.2953, 6352493, 3441733, 1.0
-2016_ttHJetToNonbb, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_mWCutfix.txt, TreeMaker2/PreSelection, 0.2118, 6513496, 3532137, 1.0
+2016_ttHJetTobb, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8.txt, TreeMaker2/PreSelection, 0.2953, 6268618, 3395996, 1.0
+2016_ttHJetToNonbb, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_mWCutfix.txt, TreeMaker2/PreSelection, 0.2118, 6521750, 3536595, 1.0
 
 # Di-boson
 2016_WWTo1L1Nu2Q, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2016_WWTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8.txt, TreeMaker2/PreSelection, 51.723, 4256802, 989667, 1.0


### PR DESCRIPTION
After disentangling 2016 and 2016v3, the following samples are "actually" missing:

TT_isrUp
TTZH
tZq_W_lept_Z_hadron