### PR TITLE
Follow upstream change in TopTagger repo: include ==> interface

### DIFF
--- a/BackgroundMVA/test/Makefile
+++ b/BackgroundMVA/test/Makefile
@@ -3,7 +3,7 @@ ODIR    = obj
 IFWDIR  = $(CMSSW_BASE)/src/Framework/Framework/include
 SFWDIR  = $(CMSSW_BASE)/src/Framework/Framework/src
 SSDIR   = $(CMSSW_BASE)/src/SusyAnaTools/Tools
-ITTDir  = $(CMSSW_BASE)/CfgParser/include
+ITTDir  = $(CMSSW_BASE)/CfgParser/interface
 STTDir  = $(CMSSW_BASE)/CfgParser/src
 TDIR    = $(CMSSW_BASE)/src
 

--- a/Framework/include/DeepEventShape.h
+++ b/Framework/include/DeepEventShape.h
@@ -2,8 +2,8 @@
 #define DEEPEVENTSHAPE_H
 
 #include "tensorflow/c/c_api.h"
-#include "TopTagger/CfgParser/include/Context.hh"
-#include "TopTagger/CfgParser/include/CfgDocument.hh"
+#include "TopTagger/CfgParser/interface/Context.hh"
+#include "TopTagger/CfgParser/interface/CfgDocument.hh"
 #include "Framework/Framework/include/Utility.h"
 
 #include "cstdlib"


### PR DESCRIPTION
Recently, a renaming of the `include` folder in the `TopTagger/CfgParser` module [1] took place. It is now called `interface`. This has been reflected in the relevant places in the `Framework` module.

[1] https://github.com/susy2015/TopTagger/commit/9bd7a884f6cc28c5e385e7e797354b7b68aa2a53