### PR TITLE
Added high mass VLQ samples to framework, changed the ranking of tops in the StopJets collection

### DIFF
--- a/Framework/cfg/sampleCollections_v6.cfg
+++ b/Framework/cfg/sampleCollections_v6.cfg
@@ -105,7 +105,7 @@
 
 2017_AllSignal_CP5, 2017_RPV_2t6j_mStop-300_CP5, 2017_RPV_2t6j_mStop-350_CP5, 2017_RPV_2t6j_mStop-400_CP5, 2017_RPV_2t6j_mStop-450_CP5, 2017_RPV_2t6j_mStop-500_CP5, 2017_RPV_2t6j_mStop-550_CP5, 2017_RPV_2t6j_mStop-600_CP5, 2017_RPV_2t6j_mStop-650_CP5, 2017_RPV_2t6j_mStop-700_CP5, 2017_RPV_2t6j_mStop-750_CP5, 2017_RPV_2t6j_mStop-800_CP5, 2017_RPV_2t6j_mStop-850_CP5, 2017_RPV_2t6j_mStop-900_CP5, 2017_StealthSYY_2t6j_mStop-300_CP5, 2017_StealthSYY_2t6j_mStop-350_CP5, 2017_StealthSYY_2t6j_mStop-400_CP5, 2017_StealthSYY_2t6j_mStop-450_CP5, 2017_StealthSYY_2t6j_mStop-500_CP5, 2017_StealthSYY_2t6j_mStop-550_CP5, 2017_StealthSYY_2t6j_mStop-600_CP5, 2017_StealthSYY_2t6j_mStop-650_CP5, 2017_StealthSYY_2t6j_mStop-700_CP5, 2017_StealthSYY_2t6j_mStop-750_CP5, 2017_StealthSYY_2t6j_mStop-800_CP5, 2017_StealthSYY_2t6j_mStop-850_CP5, 2017_StealthSYY_2t6j_mStop-900_CP5, 2017_StealthSHH_2t4b_mStop-300_CP5, 2017_StealthSHH_2t4b_mStop-350_CP5, 2017_StealthSHH_2t4b_mStop-400_CP5, 2017_StealthSHH_2t4b_mStop-450_CP5, 2017_StealthSHH_2t4b_mStop-500_CP5, 2017_StealthSHH_2t4b_mStop-550_CP5, 2017_StealthSHH_2t4b_mStop-600_CP5, 2017_StealthSHH_2t4b_mStop-650_CP5, 2017_StealthSHH_2t4b_mStop-700_CP5, 2017_StealthSHH_2t4b_mStop-750_CP5, 2017_StealthSHH_2t4b_mStop-800_CP5, 2017_StealthSHH_2t4b_mStop-850_CP5, 2017_StealthSHH_2t4b_mStop-900_CP5
 
-2017_VLQ_Signal, 2017_VLQ_2t4b_mtp-500, 2017_VLQ_2t4b_mtp-750, 2017_VLQ_2t4b_mtp-1000
+2017_VLQ_Signal, 2017_VLQ_2t4b_mtp-500, 2017_VLQ_2t4b_mtp-750, 2017_VLQ_2t4b_mtp-1000, 2017_VLQ_2t4b_mtp-1250, 2017_VLQ_2t4b_mtp-1500
 
 # ***********************************
 # **  2018 samples pre HEM failure **

--- a/Framework/cfg/sampleSets_v6.cfg
+++ b/Framework/cfg/sampleSets_v6.cfg
@@ -517,6 +517,8 @@
 2017_VLQ_2t4b_mtp-500, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-500_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 3.11, 10000, 0, 1.0
 2017_VLQ_2t4b_mtp-750, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-750_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.272, 10000, 0, 1.0
 2017_VLQ_2t4b_mtp-1000, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1000_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.0397, 10000, 0, 1.0
+2017_VLQ_2t4b_mtp-1250, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1000_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.00766, 10000, 0, 1.0
+2017_VLQ_2t4b_mtp-1500, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1000_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.00172, 10000, 0, 1.0
 
 # ***********************************
 # **  2018 samples pre HEM failure **

--- a/Framework/cfg/sampleSets_v6.cfg
+++ b/Framework/cfg/sampleSets_v6.cfg
@@ -517,8 +517,8 @@
 2017_VLQ_2t4b_mtp-500, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-500_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 3.11, 10000, 0, 1.0
 2017_VLQ_2t4b_mtp-750, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-750_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.272, 10000, 0, 1.0
 2017_VLQ_2t4b_mtp-1000, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1000_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.0397, 10000, 0, 1.0
-2017_VLQ_2t4b_mtp-1250, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1000_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.00766, 10000, 0, 1.0
-2017_VLQ_2t4b_mtp-1500, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1000_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.00172, 10000, 0, 1.0
+2017_VLQ_2t4b_mtp-1250, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1250_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.00766, 10000, 0, 1.0
+2017_VLQ_2t4b_mtp-1500, /eos/uscms/store/user/lpcsusyhad/StealthStop/filelists_Kevin_V17/, 2017_VLQ_2t4b_mtp-1500_mzeta-5000_TuneCP5_13TeV-madgraphMLM-pythia8.txt, TreeMaker2/PreSelection, 0.00172, 10000, 0, 1.0
 
 # ***********************************
 # **  2018 samples pre HEM failure **

--- a/Framework/include/StopJets.h
+++ b/Framework/include/StopJets.h
@@ -53,7 +53,9 @@ private:
         }
 
         std::sort(StopJets.begin(), StopJets.end(), utility::compare_pt_TLV);
-
+        if( StopJets.size() > 2 ) {
+            std::sort(StopJets.begin()+1, StopJets.end(), [StopJets](const TLorentzVector& v1, const TLorentzVector& v2) {return v1.Pt()*v1.DeltaR(StopJets[0]) > v2.Pt()*v2.DeltaR(StopJets[0]);});
+        }
         // get the notTopJets by using 'usedIndex' 
         std::vector<TLorentzVector> notTopJets;
         for(unsigned int i = 0; i < Jets.size(); ++i)


### PR DESCRIPTION
* Moved new VLQ samples into the StealthStop EOS area and implemented them into the framework

* Changed the ranking system for the tops in the stop jets collection. The result of this change is the second seed for the hemisphere reconstruction will now be determined by (deltaR of top with first axis)*(pt of top)