### PR TITLE
added a new ISR jet filter

### DIFF
--- a/Framework/include/ISRJets.h
+++ b/Framework/include/ISRJets.h
@@ -50,6 +50,8 @@ private:
             auto& GM_ISRmatching_justCutOnPtRatio_PtRatio = tr.createDerivedVec<double>("GM_ISRmatching_justCutOnPtRatio_PtRatio"+myVarSuffix_);
             auto& ISRmatched_dr_ptr                       = tr.createDerivedVec<bool>("ISRmatched_dr_ptr"+myVarSuffix_, Jets.size(), false);
             auto& ISRmatched_dr                           = tr.createDerivedVec<bool>("ISRmatched_dr"+myVarSuffix_, Jets.size(), false);
+            auto& GoodJets_pt20_maskedISR                 = tr.createDerivedVec<bool>("GoodJets_pt20_maskedISR"+myVarSuffix_, Jets.size(), false);
+
 
             // ---------------------------
             // Loop over the gen particles
@@ -64,7 +66,7 @@ private:
                 bool pass_ISR = ( abs(pdgId) <= 6  && abs(momPdgId) == 21 && status == 23 ) ||
                                 ( abs(pdgId) == 21 && abs(momPdgId) <= 6  && status == 23 ) || 
                                 ( abs(pdgId) == 21 && abs(momPdgId) == 21 && status == 23 ) ; 
-       
+ 
                 // ----------------------------
                 // Loop over the reco particles
                 // ----------------------------
@@ -117,7 +119,18 @@ private:
                     {
                         GM_ISRmatching_justCutOnPtRatio_DR.push_back( GenParticles.at(g).DeltaR(Jets.at(j)) );
                         GM_ISRmatching_justCutOnPtRatio_PtRatio.push_back( ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) );                        
-                    }     
+                    }  
+
+                    // -----------------------------------------------
+                    // make filter to use inside hemispheres
+                    //     -- remove the ISR jets inside GoodJets_pt20
+                    // -----------------------------------------------
+                    if ( (GoodJets_pt20[j]) && (!ISRmatched_dr_ptr[j]) )
+                    {
+                        GoodJets_pt20_maskedISR.at(j) = true;
+                    }
+
+                    tr.registerDerivedVar<int>("NGoodJets_pt20_maskedISR"+myVarSuffix_, GoodJets_pt20_maskedISR.size());   
  
                 } // reco particles
             } // Gen particles 

--- a/Framework/include/ISRJets.h
+++ b/Framework/include/ISRJets.h
@@ -72,7 +72,7 @@ private:
             for (unsigned int j = 0; j < Jets.size(); j++)
             {
                 bool passBestDR  = GenParticles.at(g).DeltaR(Jets.at(j)) < maxDR;
-                bool passBestPt  = abs ( 1 - ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) ) < maxPtRatio;
+                bool passBestPt  = ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) > ( 1 - maxPtRatio ) && ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) < ( 1 + maxPtRatio );
                 bool findParents = (findParent(check_resPartID, g, GenParticles_ParentId, GenParticles_ParentIdx) == check_resPartID && GoodGenParticles.at(g) && check_ISR);
 
                 if (findParents)
@@ -228,8 +228,8 @@ private:
             auto& ISRmatched_dr_ptr                       = tr.createDerivedVec<bool>("ISRmatched_dr_ptr"+myVarSuffix_, RecoISR.size(), false);
             auto& ISRmatched_dr                           = tr.createDerivedVec<bool>("ISRmatched_dr"+myVarSuffix_, RecoISR.size(), false);
 
-            std::vector<int> ListParticles{1, 2, 3, 4, 5, 6, -1, -2, -3, -4, -5, -6, 2212};
-            int ISR_Idx            = -1;
+            std::vector<int> ListParticles{1, 2, 3, 4, 5, 6, -1, -2, -3, -4, -5, -6, 21};
+            int ISR_Idx         = -1;
             int nISRJets_dr_ptr = 0;
             int nISRJets_dr     = 0;
 
@@ -239,7 +239,7 @@ private:
                 std::vector<std::tuple<int, int, double>> bestMatches;
                 std::vector<std::tuple<int, int, double>> justDRMatches;
                 std::vector<std::tuple<int, int, double>> justPtRatioMatches;
-                double maxDR      = 0.1; // set max DR allowed for matching
+                double maxDR      = 0.3; // set max DR allowed for matching / = 0.1
                 double maxPtRatio = 0.5; // set max pT allowed for matching
                 
                 findBestDR(GenParticles, RecoISR, GenISR, ListParticles[m], GenParticles_ParentId, GenParticles_ParentIdx, ISR_Idx, maxDR, maxPtRatio, allMatches, bestMatches, justDRMatches, justPtRatioMatches);
@@ -250,7 +250,7 @@ private:
                 for (unsigned int match = 0; match < allMatches.size(); match++)
                 {
                     GM_ISRmatching_allDR.push_back( GenParticles.at(std::get<0>(allMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(allMatches.at(match)))) );
-                    GM_ISRmatching_allPtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(allMatches.at(match))).Pt() / GenParticles.at(std::get<0>(allMatches.at(match))).Pt()) ) );
+                    GM_ISRmatching_allPtRatio.push_back( ( RecoISR.at(std::get<1>(allMatches.at(match))).Pt() / GenParticles.at(std::get<0>(allMatches.at(match))).Pt() ) );
                 }       
 
                 // -------------------------------------------
@@ -259,7 +259,7 @@ private:
                 for (unsigned int match = 0; match < bestMatches.size(); match++)
                 {
                     GM_ISRmatching_bestDR.push_back( GenParticles.at(std::get<0>(bestMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(bestMatches.at(match)))) );
-                    GM_ISRmatching_bestPtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(bestMatches.at(match))).Pt() / GenParticles.at(std::get<0>(bestMatches.at(match))).Pt()) ) );
+                    GM_ISRmatching_bestPtRatio.push_back( ( RecoISR.at(std::get<1>(bestMatches.at(match))).Pt() / GenParticles.at(std::get<0>(bestMatches.at(match))).Pt() ) );
 
                     // getting ISRmatched_dr_ptr jets
                     ISRmatched_dr_ptr.at(std::get<1>(bestMatches.at(match))) = true;
@@ -272,8 +272,8 @@ private:
                 for (unsigned int match = 0; match < justDRMatches.size(); match++)
                 {
                     GM_ISRmatching_justCutOnDR_DR.push_back( GenParticles.at(std::get<0>(justDRMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(justDRMatches.at(match)))) );
-                    GM_ISRmatching_justCutOnDR_PtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(justDRMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justDRMatches.at(match))).Pt()) ) );
-        
+                    GM_ISRmatching_justCutOnDR_PtRatio.push_back( ( RecoISR.at(std::get<1>(justDRMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justDRMatches.at(match))).Pt() ) );                
+
                     // getting ISRmatched_dr jets
                     ISRmatched_dr.at(std::get<1>(justDRMatches.at(match))) = true;
                     nISRJets_dr++;
@@ -285,7 +285,7 @@ private:
                 for (unsigned int match = 0; match < justPtRatioMatches.size(); match++)
                 {
                     GM_ISRmatching_justCutOnPtRatio_DR.push_back( GenParticles.at(std::get<0>(justPtRatioMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(justPtRatioMatches.at(match)))) );
-                    GM_ISRmatching_justCutOnPtRatio_PtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(justPtRatioMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justPtRatioMatches.at(match))).Pt()) ) );
+                    GM_ISRmatching_justCutOnPtRatio_PtRatio.push_back( ( RecoISR.at(std::get<1>(justPtRatioMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justPtRatioMatches.at(match))).Pt() ) );
                 }       
 
                 tr.registerDerivedVar("nGenISR"+myVarSuffix_, nGenISR);
@@ -295,10 +295,10 @@ private:
             
             } // ISR truth level matching loop 
 
-            // ---------------------------------------
-            // ISR filter by using TreeMaker method
-            // ---------------------------------------
-            auto& ISRfilter = tr.createDerivedVec<bool>("ISRfilter"+myVarSuffix_, Jets.size(), false);
+            // ------------------------------------------
+            // NonISR filter by using TreeMaker method
+            // ------------------------------------------
+            auto& NonISRmatched = tr.createDerivedVec<bool>("NonISRmatched"+myVarSuffix_, Jets.size(), false);
             int nISR = 0;
 
             for (unsigned int j = 0; j < Jets.size(); j++)
@@ -328,10 +328,10 @@ private:
                     }        
                 } 
                   
-                // ISRJets filter      
+                // NonISR Jets filter      
                 if(!matched)
                 {
-                    ISRfilter.at(j) = true;
+                    NonISRmatched.at(j) = true;
                     nISR++;
                 } 
                 

--- a/Framework/include/ISRJets.h
+++ b/Framework/include/ISRJets.h
@@ -20,202 +20,25 @@ class ISRJets
 private:
     std::string myVarSuffix_;
 
-    // ----------------------------------------
-    // function to find the particle parents
-    // ----------------------------------------
-    inline int findParent(const int p, const int idx, const std::vector<int>& GenParticles_ParentId, const std::vector<int>& GenParticles_ParentIdx) const
-    {
-        //std::cout << "GenParticles_ParentIdx size: " << GenParticles_ParentIdx.size() << " --- " << "Idx: " << idx << std::endl;
-     
-        if (idx == -1) 
-        {
-            return -1; 
-        }   
-        else if (GenParticles_ParentId[idx] == p)
-        {
-            return GenParticles_ParentId[idx];   
-        }
-        else
-        {
-            return findParent(p, GenParticles_ParentIdx[idx], GenParticles_ParentId, GenParticles_ParentIdx);
-        }
-    }   
-
-    // -----------------------------------------------------------------------------------------------------
-    // function to generate all possible matches between gen particles and gen jets if pass DR and pt cut
-    // -----------------------------------------------------------------------------------------------------
-    inline void findBestDR(const std::vector<TLorentzVector>& GenParticles, 
-                           const std::vector<TLorentzVector>& Jets,
-                           const std::vector<bool>& GoodGenParticles,
-                           const int resPartID,
-                           const std::vector<int>& GenParticles_ParentId,
-                           const std::vector<int>& GenParticles_ParentIdx,
-                           const int& ISR_Idx, 
-                           const double maxDR, const double maxPtRatio,
-                           std::vector<std::tuple<int, int, double>>& allDR,
-                           std::vector<std::tuple<int, int, double>>& bestAllDR,
-                           std::vector<std::tuple<int, int, double>>& justDR,
-                           std::vector<std::tuple<int, int, double>>& justPtRatio) const
-    {
-        bool check_ISR      = true;
-        int check_resPartID = resPartID;
- 
-        std::tuple<int, int, double> DRtup;
-       
-        for (unsigned int g = 0; g < GenParticles.size(); g++)
-        {
-            if (resPartID <= 6 || resPartID == 21) 
-            {
-                check_ISR = GenParticles_ParentIdx.at(g) == ISR_Idx;
-            }
-            
-            for (unsigned int j = 0; j < Jets.size(); j++)
-            {
-                bool passBestDR  = GenParticles.at(g).DeltaR(Jets.at(j)) < maxDR;
-                bool passBestPt  = ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) > ( 1 - maxPtRatio ) && ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) < ( 1 + maxPtRatio );
-                bool findParents = (findParent(check_resPartID, g, GenParticles_ParentId, GenParticles_ParentIdx) == check_resPartID && GoodGenParticles.at(g) && check_ISR);
-
-                if (findParents)
-                {
-                    // all possible matching
-                    std::get<0>(DRtup) = g;
-                    std::get<1>(DRtup) = j;
-                    std::get<2>(DRtup) = GenParticles.at(g).DeltaR(Jets.at(j));
-                    allDR.push_back(DRtup);
-
-                    // best matching
-                    if (passBestDR && passBestPt)
-                    {
-                        std::get<0>(DRtup) = g;
-                        std::get<1>(DRtup) = j;
-                        std::get<2>(DRtup) = GenParticles.at(g).DeltaR(Jets.at(j));
-                        bestAllDR.push_back(DRtup);
-                    }
-                    
-                    // matching with cutting on deltaR
-                    if (passBestDR) 
-                    {
-                        std::get<0>(DRtup) = g;
-                        std::get<1>(DRtup) = j;
-                        std::get<2>(DRtup) = GenParticles.at(g).DeltaR(Jets.at(j));
-                        justDR.push_back(DRtup);                  
-                    }
-
-                    // matching with cutting on pt ratio
-                    if (passBestPt)
-                    {
-                        std::get<0>(DRtup) = g;
-                        std::get<1>(DRtup) = j;
-                        std::get<2>(DRtup) = GenParticles.at(g).DeltaR(Jets.at(j));
-                        justPtRatio.push_back(DRtup);
-                    }    
-                }
-            }
-        }
-    }
-
-    // ----------------------------------------------------------
-    // function to sort the best GenParticles and Jets matches
-    // ----------------------------------------------------------
-    void getMatches(const std::vector<std::tuple<int, int, double>>& bestAllDR, 
-                    std::vector<std::pair<int, int>>& bestMathches, 
-                    std::vector<bool> availableDR) const
-    {
-        std::tuple<int, int, double> bestDR;
-        double minDR = 999;
-        for ( unsigned int d = 0; d < bestAllDR.size(); d++ )
-        {
-            if ( std::get<2>(bestAllDR.at(d)) < minDR && availableDR.at(d) )
-            {
-                bestDR = bestAllDR.at(d);
-                minDR  = std::get<2>(bestAllDR.at(d));
-            }
-        }
-
-        bool allgone = true;
-        for ( const auto& u : availableDR )
-        {
-            if (u) allgone = false;
-        }
-
-        if (!allgone)
-        {
-            bestMathches.push_back( std::make_pair( std::get<0>(bestDR), std::get<1>(bestDR) ) );
-        
-            for ( unsigned int d = 0; d < bestAllDR.size(); d++ )
-            {
-                if ( std::get<0>(bestAllDR.at(d)) == std::get<0>(bestDR) || std::get<1>(bestAllDR.at(d)) == std::get<1>(bestDR) )
-                {
-                    availableDR.at(d) = false;
-                }
-            } 
-            getMatches(bestAllDR, bestMathches, availableDR);
-        }
-     }
-
-    // -------------------------
-    // -- Remove the ISR jets
-    // -------------------------
+    // ----------------
+    // -- Event Loop
+    // ----------------
     void removeISRJets(NTupleReader& tr) const
     {
         const auto& runtype = tr.getVar<std::string>("runtype");
 
         if(runtype != "Data")
         {
-            const auto& Jets                   = tr.getVec<TLorentzVector>("Jets"+myVarSuffix_);
-            const auto& GoodJets_pt20          = tr.getVec<bool>("GoodJets_pt20"+myVarSuffix_);
-            const auto& GenParticles           = tr.getVec<TLorentzVector>("GenParticles"+myVarSuffix_);
-            const auto& GenParticles_PdgId     = tr.getVec<int>("GenParticles_PdgId"+myVarSuffix_);
-            const auto& GenParticles_ParentId  = tr.getVec<int>("GenParticles_ParentId"+myVarSuffix_);
-            const auto& GenParticles_ParentIdx = tr.getVec<int>("GenParticles_ParentIdx"+myVarSuffix_);
-            const auto& GenParticles_Status    = tr.getVec<int>("GenParticles_Status"+myVarSuffix_); 
-        
-            // ---------------------
-            // loop over the Jets
-            // ---------------------
-            std::vector<TLorentzVector> RecoISR;
-            int nRecoISR = 0;
-            for (unsigned int j = 0; j < Jets.size(); j++)
-            {
-                if (!GoodJets_pt20[j]) continue;
-                RecoISR.push_back(Jets.at(j));
-                nRecoISR++;
-            }
- 
-            // --------------------------------------------
-            // loop over the GenParticles to get Gen ISR 
-            // -------------------------------------------- 
-            auto& GenISR  = tr.createDerivedVec<bool>("GenISR"+myVarSuffix_, GenParticles.size(), false);
-            int   nGenISR = 0;
-            
-            for (unsigned int g = 0; g < GenParticles.size(); g++)
-            {
-                int pdgId    = GenParticles_PdgId.at(g);
-                int momPdgId = GenParticles_ParentId.at(g);
-                int status   = GenParticles_Status.at(g);
-
-                //if ( ( abs(pdgId) <= 6 || abs(pdgId) == 21 )
-                //       && ( abs(momPdgId) <= 6 || abs(momPdgId) == 21 )
-                //       && ( status == 23 ))
-                //{
-                //    std::cout << "momPdgId: " <<  momPdgId << " || " << "pdgId : " << pdgId  << " || " << "status: " << status << std::endl; 
-                //}
-
-                // mom-dau: qg, gq, gg
-                bool pass_ISR = ( abs(pdgId) <= 6  && abs(momPdgId) == 21 && status == 23 ) ||
-                                ( abs(pdgId) == 21 && abs(momPdgId) <= 6  && status == 23 ) || 
-                                ( abs(pdgId) == 21 && abs(momPdgId) == 21 && status == 23 ) ; 
-                bool filter   = GenParticles.at(g).Pt() > 20 && abs(GenParticles.at(g).Eta()) < 2.4;
-
-                if (pass_ISR && filter)
-                {
-                    GenISR.at(g) = true;
-                    nGenISR++;
-                }
-            }  
-
+            const auto& Jets                  = tr.getVec<TLorentzVector>("Jets"+myVarSuffix_);
+            const auto& GoodJets_pt20         = tr.getVec<bool>("GoodJets_pt20"+myVarSuffix_);
+            const auto& GenParticles          = tr.getVec<TLorentzVector>("GenParticles"+myVarSuffix_);
+            const auto& GenParticles_PdgId    = tr.getVec<int>("GenParticles_PdgId"+myVarSuffix_);
+            const auto& GenParticles_ParentId = tr.getVec<int>("GenParticles_ParentId"+myVarSuffix_);
+            const auto& GenParticles_Status   = tr.getVec<int>("GenParticles_Status"+myVarSuffix_); 
+       
             // ---------------------------------------
             // ISR filter by truth definition of it  
+            //     -- ISR gen matching
             // ---------------------------------------
             auto& GM_ISRmatching_allDR                    = tr.createDerivedVec<double>("GM_ISRmatching_allDR"+myVarSuffix_);
             auto& GM_ISRmatching_bestDR                   = tr.createDerivedVec<double>("GM_ISRmatching_bestDR"+myVarSuffix_);
@@ -225,89 +48,104 @@ private:
             auto& GM_ISRmatching_bestPtRatio              = tr.createDerivedVec<double>("GM_ISRmatching_bestPtRatio"+myVarSuffix_);
             auto& GM_ISRmatching_justCutOnDR_PtRatio      = tr.createDerivedVec<double>("GM_ISRmatching_justCutOnDR_PtRatio"+myVarSuffix_);
             auto& GM_ISRmatching_justCutOnPtRatio_PtRatio = tr.createDerivedVec<double>("GM_ISRmatching_justCutOnPtRatio_PtRatio"+myVarSuffix_);
-            auto& ISRmatched_dr_ptr                       = tr.createDerivedVec<bool>("ISRmatched_dr_ptr"+myVarSuffix_, RecoISR.size(), false);
-            auto& ISRmatched_dr                           = tr.createDerivedVec<bool>("ISRmatched_dr"+myVarSuffix_, RecoISR.size(), false);
+            auto& ISRmatched_dr_ptr                       = tr.createDerivedVec<bool>("ISRmatched_dr_ptr"+myVarSuffix_, Jets.size(), false);
+            auto& ISRmatched_dr                           = tr.createDerivedVec<bool>("ISRmatched_dr"+myVarSuffix_, Jets.size(), false);
 
-            std::vector<int> ListParticles{1, 2, 3, 4, 5, 6, -1, -2, -3, -4, -5, -6, 21};
-            int ISR_Idx         = -1;
-            int nISRJets_dr_ptr = 0;
-            int nISRJets_dr     = 0;
-
-            for (unsigned int m = 0; m < ListParticles.size(); m++)            
+            // ---------------------------
+            // Loop over the gen particles
+            // --------------------------- 
+            for (unsigned int g = 0; g < GenParticles.size(); g++)
             {
-                std::vector<std::tuple<int, int, double>> allMatches;               
-                std::vector<std::tuple<int, int, double>> bestMatches;
-                std::vector<std::tuple<int, int, double>> justDRMatches;
-                std::vector<std::tuple<int, int, double>> justPtRatioMatches;
-                double maxDR      = 0.3; // set max DR allowed for matching / = 0.1
-                double maxPtRatio = 0.5; // set max pT allowed for matching
-                
-                findBestDR(GenParticles, RecoISR, GenISR, ListParticles[m], GenParticles_ParentId, GenParticles_ParentIdx, ISR_Idx, maxDR, maxPtRatio, allMatches, bestMatches, justDRMatches, justPtRatioMatches);
+                int pdgId    = GenParticles_PdgId.at(g);
+                int momPdgId = GenParticles_ParentId.at(g);
+                int status   = GenParticles_Status.at(g);
 
-                // --------------------
-                // all possible matches
-                // --------------------
-                for (unsigned int match = 0; match < allMatches.size(); match++)
+                // ISR definition - mom-dau: qg, gq, gg
+                bool pass_ISR = ( abs(pdgId) <= 6  && abs(momPdgId) == 21 && status == 23 ) ||
+                                ( abs(pdgId) == 21 && abs(momPdgId) <= 6  && status == 23 ) || 
+                                ( abs(pdgId) == 21 && abs(momPdgId) == 21 && status == 23 ) ; 
+       
+                // ----------------------------
+                // Loop over the reco particles
+                // ----------------------------
+                for (unsigned int j = 0; j < Jets.size(); j++)
                 {
-                    GM_ISRmatching_allDR.push_back( GenParticles.at(std::get<0>(allMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(allMatches.at(match)))) );
-                    GM_ISRmatching_allPtRatio.push_back( ( RecoISR.at(std::get<1>(allMatches.at(match))).Pt() / GenParticles.at(std::get<0>(allMatches.at(match))).Pt() ) );
-                }       
+                    double maxDR      = 0.3; // set max DR allowed for matching / = 0.1
+                    double maxPtRatio = 0.5; // set max pT allowed for matching
 
-                // -------------------------------------------
-                // matches with cutting on deltaR and pt ratio
-                // -------------------------------------------
-                for (unsigned int match = 0; match < bestMatches.size(); match++)
-                {
-                    GM_ISRmatching_bestDR.push_back( GenParticles.at(std::get<0>(bestMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(bestMatches.at(match)))) );
-                    GM_ISRmatching_bestPtRatio.push_back( ( RecoISR.at(std::get<1>(bestMatches.at(match))).Pt() / GenParticles.at(std::get<0>(bestMatches.at(match))).Pt() ) );
+                    bool passBestDR = GenParticles.at(g).DeltaR(Jets.at(j)) < maxDR;
+                    bool passBestPt = ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) > ( 1 - maxPtRatio ) && 
+                                      ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) < ( 1 + maxPtRatio );
 
-                    // getting ISRmatched_dr_ptr jets
-                    ISRmatched_dr_ptr.at(std::get<1>(bestMatches.at(match))) = true;
-                    nISRJets_dr_ptr++;
-                }
+                    // ----------------------------
+                    // matching without any cutting
+                    // ----------------------------           
+                    if (pass_ISR)
+                    {
+                        GM_ISRmatching_allDR.push_back( GenParticles.at(g).DeltaR(Jets.at(j)) );                         
+                        GM_ISRmatching_allPtRatio.push_back( Jets.at(j).Pt() / GenParticles.at(g).Pt() );
+                    }
 
-                // ------------------------------
-                // matches with cutting on deltaR
-                // ------------------------------
-                for (unsigned int match = 0; match < justDRMatches.size(); match++)
-                {
-                    GM_ISRmatching_justCutOnDR_DR.push_back( GenParticles.at(std::get<0>(justDRMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(justDRMatches.at(match)))) );
-                    GM_ISRmatching_justCutOnDR_PtRatio.push_back( ( RecoISR.at(std::get<1>(justDRMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justDRMatches.at(match))).Pt() ) );                
+                    // --------------------------------------------
+                    // matching with cutting on deltaR and pt ratio
+                    // --------------------------------------------           
+                    if (pass_ISR && passBestDR && passBestPt)
+                    {
+                        GM_ISRmatching_bestDR.push_back( GenParticles.at(g).DeltaR(Jets.at(j)) );
+                        GM_ISRmatching_bestPtRatio.push_back( ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) );
 
-                    // getting ISRmatched_dr jets
-                    ISRmatched_dr.at(std::get<1>(justDRMatches.at(match))) = true;
-                    nISRJets_dr++;
-                }   
+                        // ISR jet filter
+                        ISRmatched_dr_ptr.at(j) = true;
+                    }
 
-                // --------------------------------
-                // matches with cutting on pt ratio
-                // --------------------------------
-                for (unsigned int match = 0; match < justPtRatioMatches.size(); match++)
-                {
-                    GM_ISRmatching_justCutOnPtRatio_DR.push_back( GenParticles.at(std::get<0>(justPtRatioMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(justPtRatioMatches.at(match)))) );
-                    GM_ISRmatching_justCutOnPtRatio_PtRatio.push_back( ( RecoISR.at(std::get<1>(justPtRatioMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justPtRatioMatches.at(match))).Pt() ) );
-                }       
+                    // -------------------------------
+                    // matching with cutting on deltaR
+                    // -------------------------------               
+                    if (pass_ISR && passBestDR)
+                    {
+                        GM_ISRmatching_justCutOnDR_DR.push_back( GenParticles.at(g).DeltaR(Jets.at(j)) );
+                        GM_ISRmatching_justCutOnDR_PtRatio.push_back( ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) );
 
-                tr.registerDerivedVar("nGenISR"+myVarSuffix_, nGenISR);
-                tr.registerDerivedVar("nRecoISR"+myVarSuffix_, nRecoISR);
-                tr.registerDerivedVar("nISRJets_dr_ptr"+myVarSuffix_, nISRJets_dr_ptr);      
-                tr.registerDerivedVar("nISRJets_dr"+myVarSuffix_, nISRJets_dr); 
-            
-            } // ISR truth level matching loop 
+                        // ISR jet filter
+                        ISRmatched_dr.at(j) = true;
+                    } 
 
-            // ------------------------------------------
-            // NonISR filter by using TreeMaker method
-            // ------------------------------------------
-            auto& NonISRmatched = tr.createDerivedVec<bool>("NonISRmatched"+myVarSuffix_, Jets.size(), false);
-            int nISR = 0;
+                    // ---------------------------------
+                    // matching with cutting on pt ratio
+                    // ---------------------------------
+                    if (pass_ISR && passBestPt)
+                    {
+                        GM_ISRmatching_justCutOnPtRatio_DR.push_back( GenParticles.at(g).DeltaR(Jets.at(j)) );
+                        GM_ISRmatching_justCutOnPtRatio_PtRatio.push_back( ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) );                        
+                    }     
+ 
+                } // reco particles
+            } // Gen particles 
 
+            // -------------------------------------------------------
+            // NonISR & Other Jets filter by using TreeMaker method
+            //     -- NonISR    : signal jets
+            //     -- OtherJets : ISR + FSR + underlying
+            // -------------------------------------------------------
+            auto& NonISRmatched_dr     = tr.createDerivedVec<bool>("NonISRmatched_dr"+myVarSuffix_, Jets.size(), false);
+            auto& NonISRmatched_dr_ptr = tr.createDerivedVec<bool>("NonISRmatched_dr_ptr"+myVarSuffix_, Jets.size(), false);
+            auto& OtherJets            = tr.createDerivedVec<bool>("OtherJets"+myVarSuffix_, Jets.size(), false);
+            int nNonISR_dr     = 0;
+            int nNonISR_dr_ptr = 0;
+            int nOtherJets     = 0;
+
+            // ----------------------------
+            // Loop over the reco particles
+            // ----------------------------
             for (unsigned int j = 0; j < Jets.size(); j++)
             {
                 if (!GoodJets_pt20[j]) continue;
         
                 bool matched = false;
 
-                // gen matching
+                // ----------------------------
+                // Loop over the gen pareticles
+                // ----------------------------
                 for (unsigned int g = 0; g < GenParticles.size(); g++)
                 {
                     if (matched) break;
@@ -316,26 +154,46 @@ private:
                     int momPdgId = GenParticles_ParentId.at(g);
                     int status   = GenParticles_Status.at(g);
  
-                    if (abs(pdgId) > 5 || abs(pdgId) != 21 || status != 23) continue;    
-                    if(!(momPdgId == 6 || momPdgId == 23   || momPdgId == 24 || momPdgId == 25 || momPdgId > 1e6)) continue;            
+                    if (abs(pdgId) > 5      || status != 23) continue;  
+                    if(!(abs(momPdgId) == 6 || abs(momPdgId) == 24 || abs(momPdgId) == 1000022 || abs(momPdgId) == 1000006)) continue;                     
+
+                    double dR    = GenParticles.at(g).DeltaR(Jets.at(j));
+                    bool ptRatio = ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) > ( 0.5 ) &&
+                                   ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) < ( 1.5 ); 
                     
-                    // check against daughter in case of hard initial splitting
-                    double dR = GenParticles.at(g).DeltaR(Jets.at(j)); 
+                    // -------------------------------
+                    // matching with cutting on deltaR
+                    // -------------------------------
                     if (dR < 0.3)
                     {
                         matched = true;
-                        break;
-                    }        
+                        NonISRmatched_dr.at(j) = true;
+                        nNonISR_dr++;
+                    }
+
+                    // --------------------------------------------
+                    // matching with cutting on deltaR and pt ratio            
+                    // --------------------------------------------
+                    if (dR < 0.3 && ptRatio)
+                    {
+                        matched = true;
+                        NonISRmatched_dr_ptr.at(j) = true;
+                        nNonISR_dr_ptr++;
+                    }
                 } 
                   
-                // NonISR Jets filter      
+                // -------------------------------------
+                // OtherJets (ISR+FSR+underlying) filter
+                // -------------------------------------      
                 if(!matched)
                 {
-                    NonISRmatched.at(j) = true;
-                    nISR++;
+                    OtherJets.at(j) = true;
+                    nOtherJets++;
                 } 
                 
-                tr.registerDerivedVar("nISR"+myVarSuffix_, nISR);
+                tr.registerDerivedVar("nNonISR_dr"+myVarSuffix_, nNonISR_dr);
+                tr.registerDerivedVar("nNonISR_dr_ptr"+myVarSuffix_, nNonISR_dr_ptr);
+                tr.registerDerivedVar("nOtherJets"+myVarSuffix_, nOtherJets);
 
             } // TreeMaker matching loop       
                 

--- a/Framework/include/ISRJets.h
+++ b/Framework/include/ISRJets.h
@@ -64,7 +64,7 @@ private:
        
         for (unsigned int g = 0; g < GenParticles.size(); g++)
         {
-            if (resPartID == 2212 )
+            if (resPartID <= 6 || resPartID == 21) 
             {
                 check_ISR = GenParticles_ParentIdx.at(g) == ISR_Idx;
             }
@@ -72,7 +72,6 @@ private:
             for (unsigned int j = 0; j < Jets.size(); j++)
             {
                 bool passBestDR  = GenParticles.at(g).DeltaR(Jets.at(j)) < maxDR;
-                //bool passBestPt  = abs( 1 - Jets.at(j).Pt() / GenParticles.at(g).Pt() ) < maxPtRatio;
                 bool passBestPt  = abs ( 1 - ( Jets.at(j).Pt() / GenParticles.at(g).Pt() ) ) < maxPtRatio;
                 bool findParents = (findParent(check_resPartID, g, GenParticles_ParentId, GenParticles_ParentIdx) == check_resPartID && GoodGenParticles.at(g) && check_ISR);
 
@@ -115,9 +114,9 @@ private:
         }
     }
 
-    // -------------------------------------------------------------
+    // ----------------------------------------------------------
     // function to sort the best GenParticles and Jets matches
-    // -------------------------------------------------------------
+    // ----------------------------------------------------------
     void getMatches(const std::vector<std::tuple<int, int, double>>& bestAllDR, 
                     std::vector<std::pair<int, int>>& bestMathches, 
                     std::vector<bool> availableDR) const
@@ -154,9 +153,9 @@ private:
         }
      }
 
-    // ----------------------
-    // Remove the ISR jets
-    // ----------------------
+    // -------------------------
+    // -- Remove the ISR jets
+    // -------------------------
     void removeISRJets(NTupleReader& tr) const
     {
         const auto& runtype = tr.getVar<std::string>("runtype");
@@ -171,9 +170,9 @@ private:
             const auto& GenParticles_ParentIdx = tr.getVec<int>("GenParticles_ParentIdx"+myVarSuffix_);
             const auto& GenParticles_Status    = tr.getVec<int>("GenParticles_Status"+myVarSuffix_); 
         
-            // ------------------
+            // ---------------------
             // loop over the Jets
-            // ------------------
+            // ---------------------
             std::vector<TLorentzVector> RecoISR;
             int nRecoISR = 0;
             for (unsigned int j = 0; j < Jets.size(); j++)
@@ -183,34 +182,42 @@ private:
                 nRecoISR++;
             }
  
-            // -----------------------------------------
+            // --------------------------------------------
             // loop over the GenParticles to get Gen ISR 
-            // ----------------------------------------- 
-            auto& GenISR = tr.createDerivedVec<bool>("GenISR"+myVarSuffix_, GenParticles.size());
-            //std::vector<bool> GenISR(GenParticles.size(), false);
-            int nGenISR = 0;
+            // -------------------------------------------- 
+            auto& GenISR  = tr.createDerivedVec<bool>("GenISR"+myVarSuffix_, GenParticles.size(), false);
+            int   nGenISR = 0;
+            
             for (unsigned int g = 0; g < GenParticles.size(); g++)
             {
-                int pdgId  = GenParticles_PdgId.at(g);
-                int momId  = GenParticles_ParentId.at(g);
-                int status = GenParticles_Status.at(g);
-                //std::cout << "pdgId: " << pdgId  << " --- " << "momId: " << momId << " --- " << "status code: " << status << std::endl;                           
+                int pdgId    = GenParticles_PdgId.at(g);
+                int momPdgId = GenParticles_ParentId.at(g);
+                int status   = GenParticles_Status.at(g);
 
-                bool is_jet   = (abs(pdgId) <= 6 || abs(pdgId) == 21);
-                bool pass_isr = is_jet ? status == 71 && (abs(momId) == 2212) : false;  
-                bool filter   = GenParticles.at(g).Pt() > 20 && abs(GenParticles.at(g).Eta()) < 2.4;           
+                //if ( ( abs(pdgId) <= 6 || abs(pdgId) == 21 )
+                //       && ( abs(momPdgId) <= 6 || abs(momPdgId) == 21 )
+                //       && ( status == 23 ))
+                //{
+                //    std::cout << "momPdgId: " <<  momPdgId << " || " << "pdgId : " << pdgId  << " || " << "status: " << status << std::endl; 
+                //}
 
-                if (pass_isr && filter)
+                // mom-dau: qg, gq, gg
+                bool pass_ISR = ( abs(pdgId) <= 6  && abs(momPdgId) == 21 && status == 23 ) ||
+                                ( abs(pdgId) == 21 && abs(momPdgId) <= 6  && status == 23 ) || 
+                                ( abs(pdgId) == 21 && abs(momPdgId) == 21 && status == 23 ) ; 
+                bool filter   = GenParticles.at(g).Pt() > 20 && abs(GenParticles.at(g).Eta()) < 2.4;
+
+                if (pass_ISR && filter)
                 {
                     GenISR.at(g) = true;
                     nGenISR++;
                 }
             }  
 
-            // ----------------
-            // ISR Gen matching
-            // ----------------
-            auto& GM_ISRmatching_allDR                    = tr.createDerivedVec<double>("GM_ISRmatching_allDR"+myVarSuffix_); 
+            // ---------------------------------------
+            // ISR filter by truth definition of it  
+            // ---------------------------------------
+            auto& GM_ISRmatching_allDR                    = tr.createDerivedVec<double>("GM_ISRmatching_allDR"+myVarSuffix_);
             auto& GM_ISRmatching_bestDR                   = tr.createDerivedVec<double>("GM_ISRmatching_bestDR"+myVarSuffix_);
             auto& GM_ISRmatching_justCutOnDR_DR           = tr.createDerivedVec<double>("GM_ISRmatching_justCutOnDR_DR"+myVarSuffix_);
             auto& GM_ISRmatching_justCutOnPtRatio_DR      = tr.createDerivedVec<double>("GM_ISRmatching_justCutOnPtRatio_DR"+myVarSuffix_);
@@ -218,19 +225,14 @@ private:
             auto& GM_ISRmatching_bestPtRatio              = tr.createDerivedVec<double>("GM_ISRmatching_bestPtRatio"+myVarSuffix_);
             auto& GM_ISRmatching_justCutOnDR_PtRatio      = tr.createDerivedVec<double>("GM_ISRmatching_justCutOnDR_PtRatio"+myVarSuffix_);
             auto& GM_ISRmatching_justCutOnPtRatio_PtRatio = tr.createDerivedVec<double>("GM_ISRmatching_justCutOnPtRatio_PtRatio"+myVarSuffix_);
-            auto& ISRmatched_dr_ptr                       = tr.createDerivedVec<bool>("ISRmatched_dr_ptr"+myVarSuffix_, RecoISR.size());
-            auto& ISRmatched_dr                           = tr.createDerivedVec<bool>("ISRmatched_dr"+myVarSuffix_, RecoISR.size());
+            auto& ISRmatched_dr_ptr                       = tr.createDerivedVec<bool>("ISRmatched_dr_ptr"+myVarSuffix_, RecoISR.size(), false);
+            auto& ISRmatched_dr                           = tr.createDerivedVec<bool>("ISRmatched_dr"+myVarSuffix_, RecoISR.size(), false);
 
             std::vector<int> ListParticles{1, 2, 3, 4, 5, 6, -1, -2, -3, -4, -5, -6, 2212};
-            std::vector<TLorentzVector> isrGenList;
-            std::vector<TLorentzVector> isrRecoList;
-            int ISR_Idx         = -1;
+            int ISR_Idx            = -1;
             int nISRJets_dr_ptr = 0;
             int nISRJets_dr     = 0;
 
-            // --------------
-            // matching loops
-            // --------------
             for (unsigned int m = 0; m < ListParticles.size(); m++)            
             {
                 std::vector<std::tuple<int, int, double>> allMatches;               
@@ -239,6 +241,7 @@ private:
                 std::vector<std::tuple<int, int, double>> justPtRatioMatches;
                 double maxDR      = 0.1; // set max DR allowed for matching
                 double maxPtRatio = 0.5; // set max pT allowed for matching
+                
                 findBestDR(GenParticles, RecoISR, GenISR, ListParticles[m], GenParticles_ParentId, GenParticles_ParentIdx, ISR_Idx, maxDR, maxPtRatio, allMatches, bestMatches, justDRMatches, justPtRatioMatches);
 
                 // --------------------
@@ -250,18 +253,11 @@ private:
                     GM_ISRmatching_allPtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(allMatches.at(match))).Pt() / GenParticles.at(std::get<0>(allMatches.at(match))).Pt()) ) );
                 }       
 
-                // ------------
-                // best matches
-                // ------------
-                std::vector<double> DRvec;
-                std::vector<double> PtVec;
-                TLorentzVector isrGenMatched;
-                TLorentzVector isrRecoMatched;
+                // -------------------------------------------
+                // matches with cutting on deltaR and pt ratio
+                // -------------------------------------------
                 for (unsigned int match = 0; match < bestMatches.size(); match++)
                 {
-                    isrGenMatched  = GenParticles.at(std::get<0>(bestMatches.at(match)));
-                    isrRecoMatched = RecoISR.at(std::get<1>(bestMatches.at(match)));
-
                     GM_ISRmatching_bestDR.push_back( GenParticles.at(std::get<0>(bestMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(bestMatches.at(match)))) );
                     GM_ISRmatching_bestPtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(bestMatches.at(match))).Pt() / GenParticles.at(std::get<0>(bestMatches.at(match))).Pt()) ) );
 
@@ -269,42 +265,83 @@ private:
                     ISRmatched_dr_ptr.at(std::get<1>(bestMatches.at(match))) = true;
                     nISRJets_dr_ptr++;
                 }
-                //isrGenList.push_back(isrGenMatched);
-                //isrRecoList.push_back(isrRecoMatched);
 
-               // ------------------------------
-               // matches with cutting on deltaR
-               // ------------------------------
-               for (unsigned int match = 0; match < justDRMatches.size(); match++)
-               {
+                // ------------------------------
+                // matches with cutting on deltaR
+                // ------------------------------
+                for (unsigned int match = 0; match < justDRMatches.size(); match++)
+                {
                     GM_ISRmatching_justCutOnDR_DR.push_back( GenParticles.at(std::get<0>(justDRMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(justDRMatches.at(match)))) );
                     GM_ISRmatching_justCutOnDR_PtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(justDRMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justDRMatches.at(match))).Pt()) ) );
         
                     // getting ISRmatched_dr jets
                     ISRmatched_dr.at(std::get<1>(justDRMatches.at(match))) = true;
                     nISRJets_dr++;
- 
-               }   
+                }   
 
-               // --------------------------------
-               // matches with cutting on pt ratio
-               // --------------------------------
-               for (unsigned int match = 0; match < justPtRatioMatches.size(); match++)
-               {
+                // --------------------------------
+                // matches with cutting on pt ratio
+                // --------------------------------
+                for (unsigned int match = 0; match < justPtRatioMatches.size(); match++)
+                {
                     GM_ISRmatching_justCutOnPtRatio_DR.push_back( GenParticles.at(std::get<0>(justPtRatioMatches.at(match))).DeltaR(RecoISR.at(std::get<1>(justPtRatioMatches.at(match)))) );
                     GM_ISRmatching_justCutOnPtRatio_PtRatio.push_back( abs( 1 - (RecoISR.at(std::get<1>(justPtRatioMatches.at(match))).Pt() / GenParticles.at(std::get<0>(justPtRatioMatches.at(match))).Pt()) ) );
-               }       
-            
-                //tr.registerDerivedVar("GM_genISR"+myVarSuffix_, isrGenList.at(0));
-                //tr.registerDerivedVar("GM_recoISR"+myVarSuffix_, isrRecoList.at(0));
-                tr.registerDerivedVar("nGenISR"+myVarSuffix_, nGenISR); 
+                }       
+
+                tr.registerDerivedVar("nGenISR"+myVarSuffix_, nGenISR);
                 tr.registerDerivedVar("nRecoISR"+myVarSuffix_, nRecoISR);
                 tr.registerDerivedVar("nISRJets_dr_ptr"+myVarSuffix_, nISRJets_dr_ptr);      
                 tr.registerDerivedVar("nISRJets_dr"+myVarSuffix_, nISRJets_dr); 
-            }
+            
+            } // ISR truth level matching loop 
+
+            // ---------------------------------------
+            // ISR filter by using TreeMaker method
+            // ---------------------------------------
+            auto& ISRfilter = tr.createDerivedVec<bool>("ISRfilter"+myVarSuffix_, Jets.size(), false);
+            int nISR = 0;
+
+            for (unsigned int j = 0; j < Jets.size(); j++)
+            {
+                if (!GoodJets_pt20[j]) continue;
+        
+                bool matched = false;
+
+                // gen matching
+                for (unsigned int g = 0; g < GenParticles.size(); g++)
+                {
+                    if (matched) break;
+
+                    int pdgId    = GenParticles_PdgId.at(g);
+                    int momPdgId = GenParticles_ParentId.at(g);
+                    int status   = GenParticles_Status.at(g);
  
-        }
-    }
+                    if (abs(pdgId) > 5 || abs(pdgId) != 21 || status != 23) continue;    
+                    if(!(momPdgId == 6 || momPdgId == 23   || momPdgId == 24 || momPdgId == 25 || momPdgId > 1e6)) continue;            
+                    
+                    // check against daughter in case of hard initial splitting
+                    double dR = GenParticles.at(g).DeltaR(Jets.at(j)); 
+                    if (dR < 0.3)
+                    {
+                        matched = true;
+                        break;
+                    }        
+                } 
+                  
+                // ISRJets filter      
+                if(!matched)
+                {
+                    ISRfilter.at(j) = true;
+                    nISR++;
+                } 
+                
+                tr.registerDerivedVar("nISR"+myVarSuffix_, nISR);
+
+            } // TreeMaker matching loop       
+                
+
+        } // data/MC loop
+    } // event loop
 
 public:    
     ISRJets(const std::string& myVarSuffix = "")

--- a/Framework/include/StopJets.h
+++ b/Framework/include/StopJets.h
@@ -27,12 +27,17 @@ private:
     // -------------------------------------
     void getStopJets(NTupleReader& tr) const
     {
-        const auto* ttr           = tr.getVar<TopTaggerResults*>("ttr");
-        const auto& Jets          = tr.getVec<TLorentzVector>("Jets");
-        const auto& GoodJets_pt20 = tr.getVec<bool>("GoodJets_pt20");
+        const auto* ttr                   = tr.getVar<TopTaggerResults*>("ttr");
+        const auto& Jets                  = tr.getVec<TLorentzVector>("Jets");
+        const auto& GoodJets_pt20         = tr.getVec<bool>("GoodJets_pt20");
+        const auto& ISRmatched_dr_ptr     = tr.getVec<bool>("ISRmatched_dr_ptr");
 
+        auto& StopJets                    = tr.createDerivedVec<TLorentzVector>("StopJets"+myVarSuffix_);
+        auto& ISRmatched_dr_ptr_maskedTop = tr.createDerivedVec<bool>("ISRmatched_dr_ptr_maskedTop"+myVarSuffix_);
+ 
+        // --------------------------------- 
         // create an index for resolved tops
-        auto& StopJets = tr.createDerivedVec<TLorentzVector>("StopJets"+myVarSuffix_);
+        // --------------------------------- 
         std::set<unsigned int> usedIndex;
         const std::vector<TopObject*>& taggedObjects = ttr->getTops();
         for(auto* t : taggedObjects)
@@ -47,30 +52,54 @@ private:
                     usedIndex.insert(index);
                     top += c->P();
                 }
-            
+         
+                // get top jets   
                 StopJets.push_back(top);
+                
+                // to filter the tops from ISR jets
+                ISRmatched_dr_ptr_maskedTop.push_back(false);               
             }
         }
 
+        // -----------------------
+        // sort the StopJets by pt
+        // -----------------------
         std::sort(StopJets.begin(), StopJets.end(), utility::compare_pt_TLV);
-        if( StopJets.size() > 2 ) {
-            std::sort(StopJets.begin()+1, StopJets.end(), [StopJets](const TLorentzVector& v1, const TLorentzVector& v2) {return v1.Pt()*v1.DeltaR(StopJets[0]) > v2.Pt()*v2.DeltaR(StopJets[0]);});
+        if( StopJets.size() > 2 ) 
+        {
+            std::sort(StopJets.begin()+1, StopJets.end(), [StopJets](const TLorentzVector& v1, const TLorentzVector& v2) 
+                {return v1.Pt()*v1.DeltaR(StopJets[0]) > v2.Pt()*v2.DeltaR(StopJets[0]);}
+            );
         }
-        // get the notTopJets by using 'usedIndex' 
-        std::vector<TLorentzVector> notTopJets;
+        
+        // -------------------------------------
+        // get the notTopJets by using usedIndex 
+        // -------------------------------------
         for(unsigned int i = 0; i < Jets.size(); ++i)
         {
             if(!GoodJets_pt20[i]) continue;
             if ( std::find(usedIndex.begin(), usedIndex.end(), i) == usedIndex.end() ) 
             {
                 StopJets.push_back(Jets[i]);
+                ISRmatched_dr_ptr_maskedTop.push_back(ISRmatched_dr_ptr[i]);
             }
         }
-    
-        // get the StopJets : add tops and not tops jets to each other
-        auto& GoodStopJets = tr.createDerivedVec<bool>("GoodStopJets"+myVarSuffix_, StopJets.size(), true);      
-        tr.createDerivedVar<int>("NGoodStopJets"+myVarSuffix_, GoodStopJets.size());
-        
+        auto& GoodStopJets = tr.createDerivedVec<bool>("GoodStopJets"+myVarSuffix_, StopJets.size(), true);
+        tr.createDerivedVar<int>("NGoodStopJets"+myVarSuffix_, GoodStopJets.size());   
+
+        // ----------------------------------------------
+        // make filter to use inside hemispheres
+        //     -- remove the ISR jets inside GoodStopJets
+        // ----------------------------------------------     
+        auto& GoodStopJets_maskedISR = tr.createDerivedVec<bool>("GoodStopJets_maskedISR"+myVarSuffix_, GoodStopJets.size(), false);
+        for (unsigned int j = 0; j < GoodStopJets.size(); ++j)
+        {
+            if (! (ISRmatched_dr_ptr_maskedTop[j]) ) 
+            {
+                GoodStopJets_maskedISR.at(j) = true;         
+            }
+        }
+        tr.createDerivedVar<int>("NGoodStopJets_maskedISR"+myVarSuffix_, GoodStopJets_maskedISR.size());        
     }
 
 public:    


### PR DESCRIPTION
(1) There has already been ISR jet filter which is below:
** Get the ISR jets by using the truth information of ISR
          -- with deltaR cut
          -- with deltaR and pT ratio cuts

(2) ISR status code was updated:
** We had used status code 71 before
    -- ISR is added by Pythia in the Parton shower level with status codes 41-49, 71-79 in MC
    -- But this status code include not only ISR but also FSR and other information
    -- So we won't use any status code from Parton shower level
** Updated ISR status code is 23
    -- ISR is added by Madgraph or Powheg in the Matrix element level with status code 23 in MC

(3) We added the new filter which is below:
** Get the NonISR jets by using the TreeMaker method
        --This method getting the NonISR jets (signal jets), which are coming from our decays

(4) We also added OtherJets (ISR+FSR+underlying) filter by using the TreeMaker Method

(5) Note that NonISR jet filter will be update for RPV and SYY signal models after figure out the FSR jet status code !!!