### PR TITLE
Update StopGenMatch to Correctly Get GEN-matched RECO Stops

### DIFF
--- a/Framework/include/StopGenMatch.h
+++ b/Framework/include/StopGenMatch.h
@@ -3,6 +3,8 @@
 #include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
 #include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
 
+// This class does gen matching to reconstruct the stops in an event both on gen level and reco level
+// In the event, that there are no stops e.g. in just ttbar+jets scenario, the "stop" should be close to the mass of the top
 class StopGenMatch
 {
 private:
@@ -27,28 +29,18 @@ private:
     //function to generate all possible matches between gen and reco particles if they pass DR and pT cut
     inline std::vector<std::tuple< int , int , double>> findAllDR(const std::vector<TLorentzVector>& GenParticles, const std::vector<TLorentzVector>& RecoParticles, 
                                                                   const std::vector<bool>& GoodGenParticles, const int resPartID, const std::vector<int>& GenParticles_ParentId, 
-                                                                  const std::vector<int>& GenParticles_ParentIdx, const int& nlino1_Idx, const int& nlino2_Idx, const double maxDR,const double maxPTratio) const
+                                                                  const std::vector<int>& GenParticles_ParentIdx, const double maxDR,const double maxPTratio) const
     {
-        bool check_neutralinos = true;
         std::vector<std::tuple< int , int, double>> AllDR;
         std::tuple< int , int, double> DRtup;
         int check_resPartID = resPartID;
-        for (unsigned int g=0; g < GenParticles.size(); g++)
+        for (unsigned int r=0; r < RecoParticles.size(); r++)
         {
-            if (resPartID == 1000022)
-            {
-                check_neutralinos = GenParticles_ParentIdx.at(g) == nlino1_Idx;
-            }
-            if (resPartID == -1000022)
-            {
-                check_resPartID = 1000022;
-                check_neutralinos = GenParticles_ParentIdx.at(g) == nlino2_Idx;
-            }
-            for (unsigned int r=0; r < RecoParticles.size(); r++)
+            for (unsigned int g=0; g < GenParticles.size(); g++)
             {
                 bool passDR = GenParticles.at(g).DeltaR(RecoParticles.at(r)) < maxDR;
-                bool passPT = abs(1 - RecoParticles.at(r).Pt()/GenParticles.at(g).Pt()) < maxPTratio;
-                if (findParent(abs(check_resPartID), g, GenParticles_ParentId, GenParticles_ParentIdx) == check_resPartID && GoodGenParticles.at(g) && check_neutralinos && passDR && passPT)
+                bool passPT = (GenParticles.at(g).Pt()/RecoParticles.at(r).Pt() > 1.0-maxPTratio and GenParticles.at(g).Pt()/RecoParticles.at(r).Pt() < 1.0+maxPTratio);
+                if (findParent(abs(check_resPartID), g, GenParticles_ParentId, GenParticles_ParentIdx) == check_resPartID && GoodGenParticles.at(g) && passDR && passPT)
                 {
                     std::get<0>(DRtup) = g;
                     std::get<1>(DRtup) = r;
@@ -83,7 +75,12 @@ private:
             Matches.push_back(std::make_pair(std::get<0>(bestDR), std::get<1>(bestDR)));
             for (unsigned int d=0;  d < AllDR.size(); d++)
             {
-                if (std::get<0>(AllDR.at(d)) == std::get<0>(bestDR) || std::get<1>(AllDR.at(d)) == std::get<1>(bestDR))
+                
+                // We only take care when a gen is used, thus it cannot be matched to multiple reco
+                // only matched to best reco. On the other hand, multiple gen are free to be matched
+                // to a single reco.
+                //if (std::get<0>(AllDR.at(d)) == std::get<0>(bestDR))
+                if (std::get<0>(AllDR.at(d)) == std::get<0>(bestDR) or (std::get<1>(AllDR.at(d)) == std::get<1>(bestDR)))
                 {
                     availableDR.at(d) = false;
                 }
@@ -98,19 +95,24 @@ private:
 
         if(runtype != "Data")
         {
-            const auto& GenParticles            = tr.getVec<TLorentzVector>("GenParticles"+myVarSuffix_);
+            const auto& GenParticles        = tr.getVec<TLorentzVector>("GenParticles"+myVarSuffix_);
             const auto& GenParticles_PdgId      = tr.getVec<int>("GenParticles_PdgId"+myVarSuffix_);
             const auto& GenParticles_ParentId   = tr.getVec<int>("GenParticles_ParentId"+myVarSuffix_);
             const auto& GenParticles_ParentIdx  = tr.getVec<int>("GenParticles_ParentIdx"+myVarSuffix_);
             const auto& GenParticles_Status     = tr.getVec<int>("GenParticles_Status"+myVarSuffix_);            
-            const auto& GoodJets_pt30           = tr.getVec<bool>("GoodJets_pt30"+myVarSuffix_);
-            const auto& GoodLeptons             = tr.getVec<std::pair<std::string, TLorentzVector>>("GoodLeptons"+myVarSuffix_);
             const auto& Jets                    = tr.getVec<TLorentzVector>("Jets"+myVarSuffix_);
+            const auto& Electrons               = tr.getVec<TLorentzVector>("Electrons"+myVarSuffix_);
+            const auto& Muons                   = tr.getVec<TLorentzVector>("Muons"+myVarSuffix_);
             const auto& MET                     = tr.getVar<double>("MET"+myVarSuffix_);
             const auto& METPhi                  = tr.getVar<double>("METPhi"+myVarSuffix_);
             const auto& GenMET                  = tr.getVar<double>("GenMET"+myVarSuffix_);
             const auto& GenMETPhi               = tr.getVar<double>("GenMETPhi"+myVarSuffix_);
-            
+
+            const auto& filetag                 = tr.getVar<std::string>("filetag");
+
+            int commonAncestor = 6;
+            if (filetag.find("mStop") != std::string::npos)
+                commonAncestor = 1000006;
 
             TLorentzVector lvMET;
             lvMET.SetPtEtaPhiM(MET, 0.0, METPhi, 0.0);
@@ -119,17 +121,20 @@ private:
             lvGenMET.SetPtEtaPhiM(GenMET, 0.0, GenMETPhi, 0.0);
 
             std::vector<TLorentzVector> RecoParticles;
-            for(unsigned int j=0; j < GoodJets_pt30.size(); j++)
+            for(unsigned int j=0; j < Jets.size(); j++)
             {
-                if(GoodJets_pt30.at(j)) RecoParticles.push_back(Jets.at(j));  //can replace this with any jet collection
+                RecoParticles.push_back(Jets.at(j));  //can replace this with any jet collection
             }
 
-            for (const auto& l : GoodLeptons)
+            for (const auto& e : Electrons)
             {
-                RecoParticles.push_back(l.second);
+                RecoParticles.push_back(e);
             }
-            std::vector<int> neutralinos_Idx;
-            int nlino1_Idx = -1, nlino2_Idx = -1;
+
+            for (const auto& m : Muons)
+            {
+                RecoParticles.push_back(m);
+            }
 
             //Define OkayParticles, which allows leptons/jets by status code and parent
             std::vector<bool> OkayGenParticles(GenParticles.size(), false);
@@ -146,97 +151,119 @@ private:
                 bool pass_lepton = is_lepton ? (status == 1) && (abs(momid) == 24 || abs(momid) == 15): false; //leptons must be status 1 and come from either a W or a tau
                 bool pass_jet = is_jet ? status == 23 : false; //pre-radiation jets must have status 23, post-radiation have status 71
                 int stopId = findParent(1000006, p, GenParticles_ParentId, GenParticles_ParentIdx);
+                int topId = findParent(6, p, GenParticles_ParentId, GenParticles_ParentIdx);
                 bool pass_stop = stopId != -1; //all gen particles must come from a stop
-                bool in_acceptance = GenParticles.at(p).Pt() > 30 && abs(GenParticles.at(p).Eta()) < 2.4; //only gen match to jets that can be reconstructed
-                bool filter = (pass_lepton || pass_jet) && pass_stop && in_acceptance;
+                bool pass_top = topId != -1; //for ttbar, gen particles can come from top
+                bool filter = (pass_lepton || pass_jet) && (pass_stop || pass_top) && true;//in_acceptance;
 
                 if (filter)
                 {
                     if (pass_lepton && WId == 24 ) WPlusLeps.push_back(p);
                     if (pass_lepton && WId == -24) WMinusLeps.push_back(p);
-                    if ((abs(pdgid) == 11 || abs(pdgid) ==13) && pass_stop &&  abs(momid) == 15) TauLepCounter += 1;
+                    if ((abs(pdgid) == 11 || abs(pdgid) ==13) && (pass_stop || pass_top) &&  abs(momid) == 15) TauLepCounter += 1;
                     OkayGenParticles.at(p) = true;
                 }
             }
             //Define GoodGenParticles, which has no W radiation (for most part) and allows undecayed taus
             std::vector<bool> GoodGenParticles = OkayGenParticles;
-            bool w_eplus = false, w_eminus = false, w_muplus = false, w_muminus =false;
-            int em = 0, ep = 0, mm = 0, mp = 0;
-            
+            bool wplus_eplus = false, wplus_eminus = false, wplus_muplus = false, wplus_muminus =false;
+            bool wminus_eplus = false, wminus_eminus = false, wminus_muplus = false, wminus_muminus =false;
+            int wpem = 0, wpep = 0, wpmm = 0, wpmp = 0;
+            int wmem = 0, wmep = 0, wmmm = 0, wmmp = 0;
+           
             for ( const auto& w : WPlusLeps) 
             {
                 if (GenParticles_PdgId.at(w) == 13)
                 {
-                    w_eminus = true;
-                    em = w;
+                    wplus_eminus = true;
+                    wpem = w;
                 }
                 if (GenParticles_PdgId.at(w) == -13)
                 {
-                    w_eplus = true;
-                    ep = w;
+                    wplus_eplus = true;
+                    wpep = w;
                 }
                 if (GenParticles_PdgId.at(w) == 11)
                 {
-                    w_muminus = true;
-                    mm = w;
+                    wplus_muminus = true;
+                    wpmm = w;
                 }
                 if (GenParticles_PdgId.at(w) == -11)
                 {
-                    w_muplus = true;
-                    mp = w;
+                    wplus_muplus = true;
+                    wpmp = w;
                 }
                     
             } //removes pair produced leptons from radation. does not remove multiple pairs, need to fix for future studies
-            if (w_eplus && w_eminus) 
+            for (const auto& w : WMinusLeps)
             {
-                GoodGenParticles.at(ep) = false;
-                GoodGenParticles.at(em) = false;
+                if (GenParticles_PdgId.at(w) == 13)
+                {
+                    wminus_eminus = true;
+                    wmem = w;
+                }
+                if (GenParticles_PdgId.at(w) == -13)
+                {
+                    wminus_eplus = true;
+                    wmep = w;
+                }
+                if (GenParticles_PdgId.at(w) == 11)
+                {
+                    wminus_muminus = true;
+                    wmmm = w;
+                }
+                if (GenParticles_PdgId.at(w) == -11)
+                {
+                    wminus_muplus = true;
+                    wmmp = w;
+                }
+
             }
-            if (w_muplus && w_muminus)
+            if (wplus_eplus && wplus_eminus) 
             {
-                GoodGenParticles.at(mp) = false;
-                GoodGenParticles.at(mm) = false;
+                GoodGenParticles.at(wpep) = false;
+                GoodGenParticles.at(wpem) = false;
             }
-                
+            if (wplus_muplus && wplus_muminus)
+            {
+                GoodGenParticles.at(wpmp) = false;
+                GoodGenParticles.at(wpmm) = false;
+            }
+            if (wminus_eminus && wminus_eplus) 
+            {
+                GoodGenParticles.at(wmep) = false;
+                GoodGenParticles.at(wmem) = false;
+            }
+            if (wminus_muminus && wminus_muplus)
+            {
+                GoodGenParticles.at(wmmp) = false;
+                GoodGenParticles.at(wmmm) = false;
+            }
+               
             bool keepTau = TauLepCounter == 0;
             for (unsigned int g=0; g < OkayGenParticles.size(); g++)
             {
-                if (abs(GenParticles_PdgId.at(g)) == 15 && GenParticles_Status.at(g) == 2 && keepTau && findParent(1000006, g, GenParticles_ParentId, GenParticles_ParentIdx) != -1) GoodGenParticles.at(g) = true;
+                if (abs(GenParticles_PdgId.at(g)) == 15 && GenParticles_Status.at(g) == 2 && keepTau && findParent(commonAncestor, g, GenParticles_ParentId, GenParticles_ParentIdx) != -1) GoodGenParticles.at(g) = true;
             }
 
-            for (unsigned int g=0; g < GenParticles.size();g++)
-            {
-                if (abs(GenParticles_PdgId.at(g)) == 1000022 && findParent(1000006, g, GenParticles_ParentId, GenParticles_ParentIdx) != -1)
-                {
-                    neutralinos_Idx.push_back(g);
-                }
+            std::vector<int> resParticleList{commonAncestor, -commonAncestor}; //gen match for stop, neutralino, and singlet
 
-            }
-            
-            if (neutralinos_Idx.size() == 2) //need to sort neutralinos by Pt
-            {
-                if (GenParticles.at(neutralinos_Idx.at(0)).Pt() > GenParticles.at(neutralinos_Idx.at(1)).Pt())
-                {
-                    nlino1_Idx = neutralinos_Idx.at(0);
-                    nlino2_Idx = neutralinos_Idx.at(1);
-                }
-                else 
-                {
-                    nlino1_Idx = neutralinos_Idx.at(1);
-                    nlino2_Idx = neutralinos_Idx.at(0);
-                }
-            }
-            
-            std::vector<int>  resParticleList{1000006, -1000006, 1000022, -1000022,  5000002, -5000002}; //gen match for stop, neutralino, and singlet
             std::vector<TLorentzVector> RecoSumList;
             std::vector<TLorentzVector> GenSumList;
             std::vector<std::pair<std::vector<double>, std::vector<double>>> DRandPTSumList;
+            std::vector<std::vector<int> > pdgsList;
+            std::vector<std::vector<int> > momList;
+            std::vector<std::vector<double> > genEtaList;
+            std::vector<std::vector<double> > recEtaList;
+            std::vector<std::vector<double> > genPhiList;
+            std::vector<std::vector<double> > recPhiList;
+            std::vector<std::vector<double> > genPtList;
+            std::vector<std::vector<double> > recPtList;
 
             TLorentzVector AllGenSum,AllGenSumNlino;
             for (unsigned int g = 0; g < GenParticles.size(); g++)
             {
-                if (GoodGenParticles.at(g) && findParent(1000006, g, GenParticles_ParentId, GenParticles_ParentIdx) == 1000006) AllGenSum += GenParticles.at(g);
-                if (GoodGenParticles.at(g) && GenParticles_ParentIdx.at(g) == nlino1_Idx) AllGenSumNlino += GenParticles.at(g);
+                if (GoodGenParticles.at(g) && findParent(commonAncestor, g, GenParticles_ParentId, GenParticles_ParentIdx) == commonAncestor) AllGenSum += GenParticles.at(g);
             }
 
 //     For tracking the DR and pT of matched particles to check matching
@@ -245,18 +272,30 @@ private:
             auto& GM_Stop1_PT     = tr.createDerivedVec<double>("GM_Stop1_PT"+myVarSuffix_);
             auto& GM_Stop2_DR     = tr.createDerivedVec<double>("GM_Stop2_DR"+myVarSuffix_);
             auto& GM_Stop2_PT     = tr.createDerivedVec<double>("GM_Stop2_PT"+myVarSuffix_);
-            auto& GM_Nlino1_DR     = tr.createDerivedVec<double>("GM_Nlino1_DR"+myVarSuffix_);
-            auto& GM_Nlino1_PT     = tr.createDerivedVec<double>("GM_Nlino1_PT"+myVarSuffix_);
-            auto& GM_Nlino2_DR     = tr.createDerivedVec<double>("GM_Nlino2_DR"+myVarSuffix_);
-            auto& GM_Nlino2_PT     = tr.createDerivedVec<double>("GM_Nlino2_PT"+myVarSuffix_);
-//begin matching
+            auto& GM_Stop1_pdgs    = tr.createDerivedVec<int>("GM_Stop1_pdgs"+myVarSuffix_);
+            auto& GM_Stop2_pdgs    = tr.createDerivedVec<int>("GM_Stop2_pdgs"+myVarSuffix_);
+            auto& GM_Stop1_mom    = tr.createDerivedVec<int>("GM_Stop1_mom"+myVarSuffix_);
+            auto& GM_Stop2_mom    = tr.createDerivedVec<int>("GM_Stop2_mom"+myVarSuffix_);
+            auto& GM_Stop1_genpts    = tr.createDerivedVec<double>("GM_Stop1_genpts"+myVarSuffix_);
+            auto& GM_Stop2_genpts    = tr.createDerivedVec<double>("GM_Stop2_genpts"+myVarSuffix_);
+            auto& GM_Stop1_genphis    = tr.createDerivedVec<double>("GM_Stop1_genphis"+myVarSuffix_);
+            auto& GM_Stop2_genphis    = tr.createDerivedVec<double>("GM_Stop2_genphis"+myVarSuffix_);
+            auto& GM_Stop1_genetas    = tr.createDerivedVec<double>("GM_Stop1_genetas"+myVarSuffix_);
+            auto& GM_Stop2_genetas    = tr.createDerivedVec<double>("GM_Stop2_genetas"+myVarSuffix_);
+            auto& GM_Stop1_recpts    = tr.createDerivedVec<double>("GM_Stop1_recpts"+myVarSuffix_);
+            auto& GM_Stop2_recpts    = tr.createDerivedVec<double>("GM_Stop2_recpts"+myVarSuffix_);
+            auto& GM_Stop1_recphis    = tr.createDerivedVec<double>("GM_Stop1_recphis"+myVarSuffix_);
+            auto& GM_Stop2_recphis    = tr.createDerivedVec<double>("GM_Stop2_recphis"+myVarSuffix_);
+            auto& GM_Stop1_recetas    = tr.createDerivedVec<double>("GM_Stop1_recetas"+myVarSuffix_);
+            auto& GM_Stop2_recetas    = tr.createDerivedVec<double>("GM_Stop2_recetas"+myVarSuffix_);
+
             for(unsigned int p=0; p < resParticleList.size(); p++)
             {
                 std::vector<std::pair<int, int>> Matches;
-                double maxDR = 0.1; //set max DR allowed for matching
-                double maxPTratio = 0.5; // set max pT allowed for matching
+                double maxDR = 0.4; //set max DR allowed for matching
+                double maxPTratio = 999.0; // set max pT allowed for matching
                 
-                std::vector<std::tuple< int , int , double>> AllDR = findAllDR(GenParticles, RecoParticles, GoodGenParticles, resParticleList[p], GenParticles_ParentId, GenParticles_ParentIdx, nlino1_Idx, nlino2_Idx, maxDR, maxPTratio);
+                std::vector<std::tuple< int , int , double>> AllDR = findAllDR(GenParticles, RecoParticles, GoodGenParticles, resParticleList[p], GenParticles_ParentId, GenParticles_ParentIdx, maxDR, maxPTratio);
 
                 std::vector<bool> availableDR(AllDR.size(), true);
 
@@ -266,27 +305,108 @@ private:
                 TLorentzVector GenMatchedSum;
                 std::vector<double> DRvec;
                 std::vector<double> PTvec;
-                for (unsigned int match = 0; match < Matches.size(); match++) //track whatever info about matches is needed
+                std::vector<int> pdgs;
+                std::vector<int> mom;
+                std::vector<double> genpts;
+                std::vector<double> genetas;
+                std::vector<double> genphis;
+                std::vector<double> recpts;
+                std::vector<double> recetas;
+                std::vector<double> recphis;
+            
+                // Matches may have multiple GEN matched to a single RECO
+                // So let's do some sneaky processing
+                unsigned int skip = 0;
+                while (skip < Matches.size())
                 {
-                    GenMatchedSum  += GenParticles.at(Matches.at(match).first);
-                    RecoMatchedSum += RecoParticles.at(Matches.at(match).second);
-                    DRvec.push_back(GenParticles.at(Matches.at(match).first).DeltaR(RecoParticles.at(Matches.at(match).second)));
-                    PTvec.push_back(abs(1 - GenParticles.at(Matches.at(match).first).Pt()/RecoParticles.at(Matches.at(match).second).Pt()));
+                    auto theGen = GenParticles.at(Matches.at(skip).first);
+                    auto theRec = RecoParticles.at(Matches.at(skip).second);
+                    int recIdx = Matches.at(skip).second;
+                    int genIdx = Matches.at(skip).first;
+
+                    // Starting from this element onward we may have the same reco appearing in a row matched
+                    // to multiple gen, so try and add all those gen together.
+                    //for (unsigned int j = skip+1; j < Matches.size(); j++)
+                    //{
+
+                    //    int currentRecIdx = Matches.at(j).second;
+                    //    skip = j;
+   
+                    //    // Here find another gen with the same reco match
+                    //    if (recIdx == currentRecIdx)
+                    //    {
+                    //        theGen += GenParticles.at(Matches.at(j).first);
+                    //    } else {
+                    //        break;
+                    //    }
+                    //}
+
+                    //std::cout << "idx: " << genIdx << " sta: " << GenParticles_Status.at(genIdx) << " mom: " << GenParticles_ParentId.at(genIdx) << " dau: " << GenParticles_PdgId.at(genIdx) << " dR: " << theGen.DeltaR(theRec) << " PtR: " << theGen.Pt()/theRec.Pt() << " eta: " << theRec.Eta() << " Phi: " << theRec.Phi() << std::endl; 
+
+                    GenMatchedSum  += theGen;
+                    RecoMatchedSum += theRec;
+                    DRvec.push_back(theGen.DeltaR(theRec));
+                    PTvec.push_back(theGen.Pt()/theRec.Pt());
+                    pdgs.push_back(GenParticles_PdgId.at(genIdx));
+                    mom.push_back(GenParticles_ParentId.at(genIdx));
+                    genetas.push_back(theGen.Eta());
+                    genphis.push_back(theGen.Phi());
+                    genpts.push_back(theGen.Pt());
+                    recetas.push_back(theRec.Eta());
+                    recphis.push_back(theRec.Phi());
+                    recpts.push_back(theRec.Pt());
+
+                    skip++;
+                    if (skip == Matches.size()) {
+                        break;
+                    }
                 }
+                //std::cout << std::endl;
                 //save info for all resonance particles in vector         
                 RecoSumList.push_back(RecoMatchedSum);
                 GenSumList.push_back(GenMatchedSum);
                 DRandPTSumList.push_back(std::make_pair(DRvec, PTvec));
+                pdgsList.push_back(pdgs);
+                momList.push_back(mom);
+                genEtaList.push_back(genetas);
+                genPhiList.push_back(genphis);
+                genPtList.push_back(genpts);
+                recEtaList.push_back(recetas);
+                recPhiList.push_back(recphis);
+                recPtList.push_back(recpts);
             }
             
+            // Let's do some weird stuff
+            // For either signal or ttbar, we will have stops or "stops"
             GM_Stop1_DR = DRandPTSumList.at(0).first;
             GM_Stop1_PT = DRandPTSumList.at(0).second;
+
             GM_Stop2_DR = DRandPTSumList.at(1).first;
             GM_Stop2_PT = DRandPTSumList.at(1).second;
-            GM_Nlino1_DR = DRandPTSumList.at(2).first;
-            GM_Nlino1_PT = DRandPTSumList.at(2).second;
-            GM_Nlino2_DR = DRandPTSumList.at(3).first;
-            GM_Nlino2_PT = DRandPTSumList.at(3).second;
+
+            GM_Stop1_pdgs = pdgsList.at(0);
+            GM_Stop2_pdgs = pdgsList.at(1);
+
+            GM_Stop1_mom = momList.at(0);
+            GM_Stop2_mom = momList.at(1);
+
+            GM_Stop1_genetas = genEtaList.at(0);
+            GM_Stop2_genetas = genEtaList.at(1);
+
+            GM_Stop1_recetas = recEtaList.at(0);
+            GM_Stop2_recetas = recEtaList.at(1);
+
+            GM_Stop1_genpts = genPtList.at(0);
+            GM_Stop2_genpts = genPtList.at(1);
+
+            GM_Stop1_recpts = recPtList.at(0);
+            GM_Stop2_recpts = recPtList.at(1);
+
+            GM_Stop1_genphis = genPhiList.at(0);
+            GM_Stop2_genphis = genPhiList.at(1);
+
+            GM_Stop1_recphis = recPhiList.at(0);
+            GM_Stop2_recphis = recPhiList.at(1);
 
             asymm_mt2_lester_bisect::disableCopyrightMessage();
             
@@ -296,17 +416,28 @@ private:
             tr.registerDerivedVar("GM_Stop2"+myVarSuffix_,      RecoSumList.at(1));
             tr.registerDerivedVar("GM_Stop1Gen"+myVarSuffix_,   GenSumList.at(0));
             tr.registerDerivedVar("GM_Stop2Gen"+myVarSuffix_,   GenSumList.at(1));            
-            tr.registerDerivedVar("GM_Nlino1"+myVarSuffix_,     RecoSumList.at(2));
-            tr.registerDerivedVar("GM_Nlino2"+myVarSuffix_,     RecoSumList.at(3));
-            tr.registerDerivedVar("GM_Nlino1Gen"+myVarSuffix_,  GenSumList.at(2));
-            tr.registerDerivedVar("GM_Nlino2Gen"+myVarSuffix_,  GenSumList.at(3));
-            tr.registerDerivedVar("GM_Single1"+myVarSuffix_,    RecoSumList.at(4));
-            tr.registerDerivedVar("GM_Single2"+myVarSuffix_,    RecoSumList.at(5));
-            tr.registerDerivedVar("GM_Single1Gen"+myVarSuffix_, GenSumList.at(4));
-            tr.registerDerivedVar("GM_Single2Gen"+myVarSuffix_, GenSumList.at(5));
             tr.registerDerivedVar("GM_AllGen"+myVarSuffix_,     AllGenSum);
             tr.registerDerivedVar("GM_AllGenNlino"+myVarSuffix_,AllGenSumNlino);
 
+            // For NN ntuples
+            if (RecoSumList.at(0).Pt() > RecoSumList.at(1).Pt())
+            {
+                tr.registerDerivedVar("stop1_ptrank_mass"+myVarSuffix_, RecoSumList.at(0).M());
+                tr.registerDerivedVar("stop2_ptrank_mass"+myVarSuffix_, RecoSumList.at(1).M());
+            } else {
+                tr.registerDerivedVar("stop1_ptrank_mass"+myVarSuffix_, RecoSumList.at(1).M());
+                tr.registerDerivedVar("stop2_ptrank_mass"+myVarSuffix_, RecoSumList.at(0).M());
+            }
+            if (RecoSumList.at(0).M() > RecoSumList.at(1).M())
+            {
+                tr.registerDerivedVar("stop1_mrank_mass"+myVarSuffix_, RecoSumList.at(0).M());
+                tr.registerDerivedVar("stop2_mrank_mass"+myVarSuffix_, RecoSumList.at(1).M());
+            } else {
+                tr.registerDerivedVar("stop1_mrank_mass"+myVarSuffix_, RecoSumList.at(1).M());
+                tr.registerDerivedVar("stop2_mrank_mass"+myVarSuffix_, RecoSumList.at(0).M());
+            }
+
+            tr.registerDerivedVar("stop_avemass"+myVarSuffix_, (RecoSumList.at(0).M()+RecoSumList.at(1).M())/2.0);
         }
     }
 


### PR DESCRIPTION
--gets GEN-matched stops or tops depending on which MC sample we are running on
--for the moment, neutralino information is discarded, see git history if wanted back