### PR TITLE
Protect Against Sneaky Out-of-Bounds in FatJetCombine

### DIFF
--- a/Framework/include/FatJetCombine.h
+++ b/Framework/include/FatJetCombine.h
@@ -111,8 +111,9 @@ private:
 
         if (NGoodLeptons == 2)
         {
-            bottom1 = Jets[TwoLep_Mbl1_Idx.first];
-            bottom2 = Jets[TwoLep_Mbl2_Idx.first];
+
+            if (TwoLep_Mbl1_Idx.first != -1) bottom1 = Jets[TwoLep_Mbl1_Idx.first];
+            if (TwoLep_Mbl2_Idx.first != -1) bottom2 = Jets[TwoLep_Mbl2_Idx.first];
         }
         else
         {


### PR DESCRIPTION
There was one place in `FatJetCombine.h` where `TLorentzVector`s could be grabbed from the -1 element of  a vector (if the index in the vector was never determined beyond the initial value of -1). This would sometimes lead to obscure `TVector2` errors about NaNs coming from the `TVector2::Phi_mpi_pi` function. A simple protection is added to prevent this from occurring.