### PR TITLE
Sort Out Abuse/Misuse of myVarSuffix_

### DIFF
--- a/Framework/include/BTagCorrector.h
+++ b/Framework/include/BTagCorrector.h
@@ -7,10 +7,7 @@
 #include "SusyAnaTools/Tools/SATException.h"
 
 //ROOT headers
-#include <TROOT.h>
-#include "TMath.h"
 #include <TFile.h>
-#include <TTree.h>
 #include <TLorentzVector.h>
 #include "TH2.h"
 

--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -17,7 +17,7 @@ private:
         const auto& TriggerPass            = tr.getVec<int>("TriggerPass");
         const auto& NNonIsoMuons           = tr.getVar<int>("NNonIsoMuons"+myVarSuffix_);
         const auto& NGoodLeptons           = tr.getVar<int>("NGoodLeptons"+myVarSuffix_);
-        const auto& GoodLeptonsCharge      = tr.getVec<int>("GoodLeptonsCharge");
+        const auto& GoodLeptonsCharge      = tr.getVec<int>("GoodLeptonsCharge"+myVarSuffix_);
         const auto& NGoodMuons             = tr.getVar<int>("NGoodMuons"+myVarSuffix_);
         const auto& NGoodPlusMuons         = tr.getVar<int>("NGoodPlusMuons"+myVarSuffix_);
         const auto& NGoodMinusMuons        = tr.getVar<int>("NGoodMinusMuons"+myVarSuffix_);
@@ -25,7 +25,7 @@ private:
         const auto& NGoodPlusElectrons     = tr.getVar<int>("NGoodPlusElectrons"+myVarSuffix_);
         const auto& NGoodMinusElectrons    = tr.getVar<int>("NGoodMinusElectrons"+myVarSuffix_);
         const auto& NGoodLeptons_pt20      = tr.getVar<int>("NGoodLeptons_pt20"+myVarSuffix_);
-        const auto& GoodLeptonsCharge_pt20 = tr.getVec<int>("GoodLeptonsCharge_pt20");
+        const auto& GoodLeptonsCharge_pt20 = tr.getVec<int>("GoodLeptonsCharge_pt20"+myVarSuffix_);
         const auto& HT_trigger_pt30        = tr.getVar<double>("HT_trigger_pt30"+myVarSuffix_);
         const auto& HT_trigger_pt45        = tr.getVar<double>("HT_trigger_pt45"+myVarSuffix_);
         const auto& HT_NonIsoMuon_pt30     = tr.getVar<double>("HT_NonIsoMuon_pt30"+myVarSuffix_);
@@ -42,8 +42,8 @@ private:
         const auto& passHEMVeto            = tr.getVar<bool>("passHEMVeto"+myVarSuffix_);
         const auto& passTrigSFHEMVeto      = tr.getVar<bool>("passTrigSFHEMVeto"+myVarSuffix_);
         const auto& NGoodBJetsCSV_pt30     = tr.getVar<int>("NGoodBJetsCSV_pt30"+myVarSuffix_); 
-        const auto& ntops                  = tr.getVar<int>("ntops");
-        const auto& dR_bjets               = tr.getVar<double>("dR_bjets"); 
+        const auto& ntops                  = tr.getVar<int>("ntops"+myVarSuffix_);
+        const auto& dR_bjets               = tr.getVar<double>("dR_bjets"+myVarSuffix_); 
  
         // ------------------------------
         // -- Data dependent stuff
@@ -128,14 +128,14 @@ private:
                 filetag.find("TTJets_SingleLeptFromTbar") != std::string::npos || 
                 filetag.find("TTJets_DiLept") != std::string::npos) && madHT > 600) 
             {
-                passMadHT = false;
+                passMadHT = true;
             }
             // also remove lepton overlap from the inclusive sample
             const auto& GenElectrons        = tr.getVec<TLorentzVector>("GenElectrons");
             const auto& GenMuons            = tr.getVec<TLorentzVector>("GenMuons");
             const auto& GenTaus             = tr.getVec<TLorentzVector>("GenTaus");
             int NGenLeptons = GenElectrons.size() + GenMuons.size() + GenTaus.size();
-            if (filetag.find("TTJets_Incl") != std::string::npos && NGenLeptons > 0) passMadHT = false;
+            if (filetag.find("TTJets_Incl") != std::string::npos && NGenLeptons > 0) passMadHT = true;
             
             // MC modeling of the trigger
             if( !passTriggerAllHad ) passTriggerHadMC = false;

--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -128,14 +128,14 @@ private:
                 filetag.find("TTJets_SingleLeptFromTbar") != std::string::npos || 
                 filetag.find("TTJets_DiLept") != std::string::npos) && madHT > 600) 
             {
-                passMadHT = true;
+                passMadHT = false;
             }
             // also remove lepton overlap from the inclusive sample
             const auto& GenElectrons        = tr.getVec<TLorentzVector>("GenElectrons");
             const auto& GenMuons            = tr.getVec<TLorentzVector>("GenMuons");
             const auto& GenTaus             = tr.getVec<TLorentzVector>("GenTaus");
             int NGenLeptons = GenElectrons.size() + GenMuons.size() + GenTaus.size();
-            if (filetag.find("TTJets_Incl") != std::string::npos && NGenLeptons > 0) passMadHT = true;
+            if (filetag.find("TTJets_Incl") != std::string::npos && NGenLeptons > 0) passMadHT = false;
             
             // MC modeling of the trigger
             if( !passTriggerAllHad ) passTriggerHadMC = false;

--- a/Framework/include/EventShapeVariables.h
+++ b/Framework/include/EventShapeVariables.h
@@ -20,10 +20,7 @@
 	   Christian Veelken, UC Davis
 */
 
-//////////#include "DataFormats/Math/interface/Vector3D.h"
 #include "Framework/Framework/include/Vector3D.h"
-//////////#include "DataFormats/Candidate/interface/Candidate.h"
-//////////#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 #include "TMatrixDSym.h"
 #include "TVectorD.h"

--- a/Framework/include/FatJetCombine.h
+++ b/Framework/include/FatJetCombine.h
@@ -3,7 +3,6 @@
 
 #include "Framework/Framework/include/Utility.h"
 #include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
-#include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
 
 class FatJetCombine
 {
@@ -182,7 +181,6 @@ private:
             }
         } 
 
-        asymm_mt2_lester_bisect::disableCopyrightMessage();
         tr.registerDerivedVar("NGoodJetsAK8"+myVarSuffix_, NGoodJetsAK8);
         tr.registerDerivedVar("NCandidateLSP"+myVarSuffix_, NCandidateLSP);
         

--- a/Framework/include/FatJetCombine.h
+++ b/Framework/include/FatJetCombine.h
@@ -2,7 +2,6 @@
 #define FATJETCOMBINE_H
 
 #include "Framework/Framework/include/Utility.h"
-#include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
 
 class FatJetCombine
 {

--- a/Framework/include/FatJetCombine.h
+++ b/Framework/include/FatJetCombine.h
@@ -12,16 +12,14 @@ private:
 
     void fatjetcombine(NTupleReader& tr)
     {
-        const auto& JetsAK8               = tr.getVec<TLorentzVector>("JetsAK8");
-        const auto& Tau1                  = tr.getVec<double>("JetsAK8_NsubjettinessTau1");
-        const auto& Tau2                  = tr.getVec<double>("JetsAK8_NsubjettinessTau2");
-        const auto& Tau3                  = tr.getVec<double>("JetsAK8_NsubjettinessTau3");
-        const auto& softDropMass          = tr.getVec<double>("JetsAK8_softDropMass");
-        const auto& prunedMass            = tr.getVec<double>("JetsAK8_prunedMass");
+        const auto& JetsAK8               = tr.getVec<TLorentzVector>("JetsAK8"+myVarSuffix_);
+        const auto& Tau1                  = tr.getVec<double>("JetsAK8"+myVarSuffix_+"_NsubjettinessTau1");
+        const auto& Tau2                  = tr.getVec<double>("JetsAK8"+myVarSuffix_+"_NsubjettinessTau2");
+        const auto& Tau3                  = tr.getVec<double>("JetsAK8"+myVarSuffix_+"_NsubjettinessTau3");
+        const auto& softDropMass          = tr.getVec<double>("JetsAK8"+myVarSuffix_+"_softDropMass");
+        const auto& prunedMass            = tr.getVec<double>("JetsAK8"+myVarSuffix_+"_prunedMass");
         const auto& Muons                 = tr.getVec<TLorentzVector>("Muons");
-//        const auto& GoodMuons             = tr.getVec<bool>("GoodMuons"+myVarSuffix_);
         const auto& Electrons             = tr.getVec<TLorentzVector>("Electrons");
-//        const auto& GoodElectrons         = tr.getVec<bool>("GoodElectrons"+myVarSuffix_);
         const auto& NMuons                = tr.getVar<int>("NGoodMuons"+myVarSuffix_);
         const auto& NElectrons            = tr.getVar<int>("NGoodElectrons"+myVarSuffix_);
         const auto& GoodBJets_pt30        = tr.getVec<bool>("GoodBJets_pt30"+myVarSuffix_);
@@ -30,13 +28,11 @@ private:
         const auto& TwoLep_Mbl2_Idx      = tr.getVar<std::pair<int, int>>("TwoLep_Mbl2_Idx"+myVarSuffix_);
         
         const auto& Jets                 = tr.getVec<TLorentzVector>("Jets"+myVarSuffix_);
-//        const auto& GoodLeptons          = tr.getVec<std::pair<std::string,TLorentzVector>>("GoodLeptons"+myVarSuffix_);
         const auto& NGoodLeptons         = tr.getVar<int>("NGoodLeptons_pt20"+myVarSuffix_);
 
-        const auto& subjets              = tr.getVec<std::vector<TLorentzVector>>("JetsAK8_subjets");
+        const auto& subjets              = tr.getVec<std::vector<TLorentzVector>>("JetsAK8"+myVarSuffix_+"_subjets");
 
         //First clean out leptons from JetsAK8 collection
-
         auto& GoodJetsAK8         = tr.createDerivedVec<bool>("GoodJetsAK8"+myVarSuffix_);
         for (unsigned int j = 0; j < JetsAK8.size(); j++)
         {
@@ -54,7 +50,6 @@ private:
                 {
                     TLorentzVector myJet = JetsAK8.at(j);
                     if( std::fabs(myMuon.Pt() - myJet.Pt()) / myMuon.Pt() < 1 && myMuon.DeltaR(myJet) < minDeltaR)
-//                    if(myMuon.DeltaR(myJet) < minDeltaR)
                     {
                         minDeltaR = myMuon.DeltaR(myJet);
                         muonCand = j;
@@ -75,7 +70,6 @@ private:
                 {
                     TLorentzVector myJet = JetsAK8.at(j);
                     if( std::fabs(myElec.Pt() - myJet.Pt()) / myElec.Pt() < 1 && myElec.DeltaR(myJet) < minDeltaR)
-                        //if(myElec.DeltaR(myJet) < minDeltaR)
                     {
                         minDeltaR = myElec.DeltaR(myJet);
                         elecCand = j;                  
@@ -91,7 +85,6 @@ private:
         {
             if(abs(JetsAK8.at(j).Eta()) > 2.4) GoodJetsAK8.at(j) = false;
             if(JetsAK8.at(j).Pt() < 170) GoodJetsAK8.at(j) = false;
-//            if(softDropMass.at(j) < 20) GoodJetsAK8.at(j) = false;
             if(GoodJetsAK8.at(j)) NGoodJetsAK8 += 1;
         }
 

--- a/Framework/include/ISRJets.h
+++ b/Framework/include/ISRJets.h
@@ -3,12 +3,6 @@
 
 #include "Framework/Framework/include/Utility.h"
 
-#include "TopTagger/TopTagger/interface/TopTaggerResults.h"
-#include "TopTagger/TopTagger/interface/TopObject.h"
-#include "TopTagger/TopTagger/interface/Constituent.h"
-
-#include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
-
 #include "TLorentzVector.h"
 #include <iostream> 
 #include <vector>

--- a/Framework/include/ISRJets.h
+++ b/Framework/include/ISRJets.h
@@ -31,10 +31,10 @@ private:
         {
             const auto& Jets                  = tr.getVec<TLorentzVector>("Jets"+myVarSuffix_);
             const auto& GoodJets_pt20         = tr.getVec<bool>("GoodJets_pt20"+myVarSuffix_);
-            const auto& GenParticles          = tr.getVec<TLorentzVector>("GenParticles"+myVarSuffix_);
-            const auto& GenParticles_PdgId    = tr.getVec<int>("GenParticles_PdgId"+myVarSuffix_);
-            const auto& GenParticles_ParentId = tr.getVec<int>("GenParticles_ParentId"+myVarSuffix_);
-            const auto& GenParticles_Status   = tr.getVec<int>("GenParticles_Status"+myVarSuffix_); 
+            const auto& GenParticles          = tr.getVec<TLorentzVector>("GenParticles");
+            const auto& GenParticles_PdgId    = tr.getVec<int>("GenParticles_PdgId");
+            const auto& GenParticles_ParentId = tr.getVec<int>("GenParticles_ParentId");
+            const auto& GenParticles_Status   = tr.getVec<int>("GenParticles_Status"); 
        
             // ---------------------------------------
             // ISR filter by truth definition of it  

--- a/Framework/include/ISRJets.h
+++ b/Framework/include/ISRJets.h
@@ -8,7 +8,6 @@
 #include "TopTagger/TopTagger/interface/Constituent.h"
 
 #include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
-#include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
 
 #include "TLorentzVector.h"
 #include <iostream> 

--- a/Framework/include/MakeStopHemispheres.h
+++ b/Framework/include/MakeStopHemispheres.h
@@ -3,6 +3,7 @@
 
 #include "Framework/Framework/include/Hemispheres.h"
 #include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
+#include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
 #include <vector>
 #include <iostream>
 #include <cmath>

--- a/Framework/include/MakeStopHemispheres.h
+++ b/Framework/include/MakeStopHemispheres.h
@@ -2,7 +2,6 @@
 #define MakeStopHemispheres_h
 
 #include "Framework/Framework/include/Hemispheres.h"
-#include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
 #include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
 #include <vector>
 #include <iostream>

--- a/Framework/include/MakeStopHemispheres.h
+++ b/Framework/include/MakeStopHemispheres.h
@@ -10,7 +10,7 @@
 class MakeStopHemispheres
 {
 private:
-    std::string jetName_, jetMaskName_, nJetName_, myVarSuffix_;
+    std::string jetName_, jetMaskName_, nJetName_, label_, myVarSuffix_;
     Hemisphere::SeedMethod seedMethod_;
 
     template<typename T> void orderVars(T& stop1, T& stop2, const T hemi1, const T hemi2, const bool hemi1ToStop1) const
@@ -31,12 +31,12 @@ private:
     {
         const auto& met               = tr.getVar<double>("MET");
         const auto& metPhi            = tr.getVar<double>("METPhi");
-        const auto& Jets              = tr.getVec<TLorentzVector>(jetName_);
-        const auto& GoodJets          = tr.getVec<bool>(jetMaskName_);
-        const auto& NGoodJets         = tr.getVar<int>(nJetName_);
-        const auto& GoodLeptons       = tr.getVec<std::pair<std::string, TLorentzVector>>("GoodLeptons");
-        const auto& event_beta_z      = tr.getVar<double>("event_beta_z"); // for NN
-        const auto& event_phi_rotate  = tr.getVar<double>("event_phi_rotate"); // for NN      
+        const auto& Jets              = tr.getVec<TLorentzVector>(jetName_+myVarSuffix_);
+        const auto& GoodJets          = tr.getVec<bool>(jetMaskName_+myVarSuffix_);
+        const auto& NGoodJets         = tr.getVar<int>(nJetName_+myVarSuffix_);
+        const auto& GoodLeptons       = tr.getVec<std::pair<std::string, TLorentzVector>>("GoodLeptons"+myVarSuffix_);
+        const auto& event_beta_z      = tr.getVar<double>("event_beta_z"+myVarSuffix_); // for NN
+        const auto& event_phi_rotate  = tr.getVar<double>("event_phi_rotate"+myVarSuffix_); // for NN      
 
         static const int hemi_association = 3; // 3: 3th method, 'lund' used by MT2  
 
@@ -152,68 +152,69 @@ private:
 
         }
         // without any rank
-        tr.registerDerivedVar("MT2_cm"+myVarSuffix_,MT2_cm);
-        tr.registerDerivedVar("dR_Stop1Stop2_cm"+myVarSuffix_,dR_Stop1Stop2_cm);
-        tr.registerDerivedVar("dPhi_Stop1Stop2_cm"+myVarSuffix_,dPhi_Stop1Stop2_cm);
-        tr.registerDerivedVar("Stop1_mass_cm"+myVarSuffix_,Stop1_cm.M());
-        tr.registerDerivedVar("Stop2_mass_cm"+myVarSuffix_,Stop2_cm.M());
-        tr.registerDerivedVar("Stop1_pt_cm"+myVarSuffix_,Stop1_cm.Pt());
-        tr.registerDerivedVar("Stop2_pt_cm"+myVarSuffix_,Stop2_cm.Pt());
-        tr.registerDerivedVar("Stop1_phi_cm"+myVarSuffix_,Stop1_cm.Phi());
-        tr.registerDerivedVar("Stop2_phi_cm"+myVarSuffix_,Stop2_cm.Phi());
-        tr.registerDerivedVar("Stop1_eta_cm"+myVarSuffix_,Stop1_cm.Eta());
-        tr.registerDerivedVar("Stop2_eta_cm"+myVarSuffix_,Stop2_cm.Eta());
-        tr.registerDerivedVar("Stop1_scalarPt_cm"+myVarSuffix_,Stop1ScalarPt);
-        tr.registerDerivedVar("Stop2_scalarPt_cm"+myVarSuffix_,Stop2ScalarPt);
+        tr.registerDerivedVar("MT2_cm"+label_+myVarSuffix_,MT2_cm);
+        tr.registerDerivedVar("dR_Stop1Stop2_cm"+label_+myVarSuffix_,dR_Stop1Stop2_cm);
+        tr.registerDerivedVar("dPhi_Stop1Stop2_cm"+label_+myVarSuffix_,dPhi_Stop1Stop2_cm);
+        tr.registerDerivedVar("Stop1_mass_cm"+label_+myVarSuffix_,Stop1_cm.M());
+        tr.registerDerivedVar("Stop2_mass_cm"+label_+myVarSuffix_,Stop2_cm.M());
+        tr.registerDerivedVar("Stop1_pt_cm"+label_+myVarSuffix_,Stop1_cm.Pt());
+        tr.registerDerivedVar("Stop2_pt_cm"+label_+myVarSuffix_,Stop2_cm.Pt());
+        tr.registerDerivedVar("Stop1_phi_cm"+label_+myVarSuffix_,Stop1_cm.Phi());
+        tr.registerDerivedVar("Stop2_phi_cm"+label_+myVarSuffix_,Stop2_cm.Phi());
+        tr.registerDerivedVar("Stop1_eta_cm"+label_+myVarSuffix_,Stop1_cm.Eta());
+        tr.registerDerivedVar("Stop2_eta_cm"+label_+myVarSuffix_,Stop2_cm.Eta());
+        tr.registerDerivedVar("Stop1_scalarPt_cm"+label_+myVarSuffix_,Stop1ScalarPt);
+        tr.registerDerivedVar("Stop2_scalarPt_cm"+label_+myVarSuffix_,Stop2ScalarPt);
         // Pt Rank
-        tr.registerDerivedVar("Stop1_PtRank"+myVarSuffix_,Stop1_PtRank);
-        tr.registerDerivedVar("Stop2_PtRank"+myVarSuffix_,Stop2_PtRank);
-        tr.registerDerivedVar("Stop1_mass_PtRank_cm"+myVarSuffix_,Stop1_PtRank_cm.M()); 
-        tr.registerDerivedVar("Stop2_mass_PtRank_cm"+myVarSuffix_,Stop2_PtRank_cm.M());
-        tr.registerDerivedVar("Stop1_pt_PtRank_cm"+myVarSuffix_,Stop1_PtRank_cm.Pt());
-        tr.registerDerivedVar("Stop2_pt_PtRank_cm"+myVarSuffix_,Stop2_PtRank_cm.Pt());
-        tr.registerDerivedVar("Stop1_phi_PtRank_cm"+myVarSuffix_,Stop1_PtRank_cm.Phi());
-        tr.registerDerivedVar("Stop2_phi_PtRank_cm"+myVarSuffix_,Stop2_PtRank_cm.Phi());
-        tr.registerDerivedVar("Stop1_eta_PtRank_cm"+myVarSuffix_,Stop1_PtRank_cm.Eta());
-        tr.registerDerivedVar("Stop2_eta_PtRank_cm"+myVarSuffix_,Stop2_PtRank_cm.Eta());
+        tr.registerDerivedVar("Stop1_PtRank"+label_+myVarSuffix_,Stop1_PtRank);
+        tr.registerDerivedVar("Stop2_PtRank"+label_+myVarSuffix_,Stop2_PtRank);
+        tr.registerDerivedVar("Stop1_mass_PtRank_cm"+label_+myVarSuffix_,Stop1_PtRank_cm.M()); 
+        tr.registerDerivedVar("Stop2_mass_PtRank_cm"+label_+myVarSuffix_,Stop2_PtRank_cm.M());
+        tr.registerDerivedVar("Stop1_pt_PtRank_cm"+label_+myVarSuffix_,Stop1_PtRank_cm.Pt());
+        tr.registerDerivedVar("Stop2_pt_PtRank_cm"+label_+myVarSuffix_,Stop2_PtRank_cm.Pt());
+        tr.registerDerivedVar("Stop1_phi_PtRank_cm"+label_+myVarSuffix_,Stop1_PtRank_cm.Phi());
+        tr.registerDerivedVar("Stop2_phi_PtRank_cm"+label_+myVarSuffix_,Stop2_PtRank_cm.Phi());
+        tr.registerDerivedVar("Stop1_eta_PtRank_cm"+label_+myVarSuffix_,Stop1_PtRank_cm.Eta());
+        tr.registerDerivedVar("Stop2_eta_PtRank_cm"+label_+myVarSuffix_,Stop2_PtRank_cm.Eta());
         // Mask Rank
-        tr.registerDerivedVar("Stop1_MassRank"+myVarSuffix_,Stop1_MassRank);
-        tr.registerDerivedVar("Stop2_MassRank"+myVarSuffix_,Stop2_MassRank);
-        tr.registerDerivedVar("Stop1_mass_MassRank_cm"+myVarSuffix_,Stop1_MassRank_cm.M()); 
-        tr.registerDerivedVar("Stop2_mass_MassRank_cm"+myVarSuffix_,Stop2_MassRank_cm.M());
-        tr.registerDerivedVar("Stop1_pt_MassRank_cm"+myVarSuffix_,Stop1_MassRank_cm.Pt());
-        tr.registerDerivedVar("Stop2_pt_MassRank_cm"+myVarSuffix_,Stop2_MassRank_cm.Pt());
-        tr.registerDerivedVar("Stop1_phi_MassRank_cm"+myVarSuffix_,Stop1_MassRank_cm.Phi());
-        tr.registerDerivedVar("Stop2_phi_MassRank_cm"+myVarSuffix_,Stop2_MassRank_cm.Phi());
-        tr.registerDerivedVar("Stop1_eta_MassRank_cm"+myVarSuffix_,Stop1_MassRank_cm.Eta());
-        tr.registerDerivedVar("Stop2_eta_MassRank_cm"+myVarSuffix_,Stop2_MassRank_cm.Eta());
+        tr.registerDerivedVar("Stop1_MassRank"+label_+myVarSuffix_,Stop1_MassRank);
+        tr.registerDerivedVar("Stop2_MassRank"+label_+myVarSuffix_,Stop2_MassRank);
+        tr.registerDerivedVar("Stop1_mass_MassRank_cm"+label_+myVarSuffix_,Stop1_MassRank_cm.M()); 
+        tr.registerDerivedVar("Stop2_mass_MassRank_cm"+label_+myVarSuffix_,Stop2_MassRank_cm.M());
+        tr.registerDerivedVar("Stop1_pt_MassRank_cm"+label_+myVarSuffix_,Stop1_MassRank_cm.Pt());
+        tr.registerDerivedVar("Stop2_pt_MassRank_cm"+label_+myVarSuffix_,Stop2_MassRank_cm.Pt());
+        tr.registerDerivedVar("Stop1_phi_MassRank_cm"+label_+myVarSuffix_,Stop1_MassRank_cm.Phi());
+        tr.registerDerivedVar("Stop2_phi_MassRank_cm"+label_+myVarSuffix_,Stop2_MassRank_cm.Phi());
+        tr.registerDerivedVar("Stop1_eta_MassRank_cm"+label_+myVarSuffix_,Stop1_MassRank_cm.Eta());
+        tr.registerDerivedVar("Stop2_eta_MassRank_cm"+label_+myVarSuffix_,Stop2_MassRank_cm.Eta());
         // ScalarPt Rank
-        tr.registerDerivedVar("Stop1_ScalarPtRank"+myVarSuffix_,Stop1_ScalarPtRank);
-        tr.registerDerivedVar("Stop2_ScalarPtRank"+myVarSuffix_,Stop2_ScalarPtRank);
-        tr.registerDerivedVar("Stop1_mass_ScalarPtRank_cm"+myVarSuffix_,Stop1_ScalarPtRank_cm.M());
-        tr.registerDerivedVar("Stop2_mass_ScalarPtRank_cm"+myVarSuffix_,Stop2_ScalarPtRank_cm.M());
-        tr.registerDerivedVar("Stop1_pt_ScalarPtRank_cm"+myVarSuffix_,Stop1_ScalarPtRank_cm.Pt());
-        tr.registerDerivedVar("Stop2_pt_ScalarPtRank_cm"+myVarSuffix_,Stop2_ScalarPtRank_cm.Pt());
-        tr.registerDerivedVar("Stop1_phi_ScalarPtRank_cm"+myVarSuffix_,Stop1_ScalarPtRank_cm.Phi());
-        tr.registerDerivedVar("Stop2_phi_ScalarPtRank_cm"+myVarSuffix_,Stop2_ScalarPtRank_cm.Phi());
-        tr.registerDerivedVar("Stop1_eta_ScalarPtRank_cm"+myVarSuffix_,Stop1_ScalarPtRank_cm.Eta());
-        tr.registerDerivedVar("Stop2_eta_ScalarPtRank_cm"+myVarSuffix_,Stop2_ScalarPtRank_cm.Eta());
+        tr.registerDerivedVar("Stop1_ScalarPtRank"+label_+myVarSuffix_,Stop1_ScalarPtRank);
+        tr.registerDerivedVar("Stop2_ScalarPtRank"+label_+myVarSuffix_,Stop2_ScalarPtRank);
+        tr.registerDerivedVar("Stop1_mass_ScalarPtRank_cm"+label_+myVarSuffix_,Stop1_ScalarPtRank_cm.M());
+        tr.registerDerivedVar("Stop2_mass_ScalarPtRank_cm"+label_+myVarSuffix_,Stop2_ScalarPtRank_cm.M());
+        tr.registerDerivedVar("Stop1_pt_ScalarPtRank_cm"+label_+myVarSuffix_,Stop1_ScalarPtRank_cm.Pt());
+        tr.registerDerivedVar("Stop2_pt_ScalarPtRank_cm"+label_+myVarSuffix_,Stop2_ScalarPtRank_cm.Pt());
+        tr.registerDerivedVar("Stop1_phi_ScalarPtRank_cm"+label_+myVarSuffix_,Stop1_ScalarPtRank_cm.Phi());
+        tr.registerDerivedVar("Stop2_phi_ScalarPtRank_cm"+label_+myVarSuffix_,Stop2_ScalarPtRank_cm.Phi());
+        tr.registerDerivedVar("Stop1_eta_ScalarPtRank_cm"+label_+myVarSuffix_,Stop1_ScalarPtRank_cm.Eta());
+        tr.registerDerivedVar("Stop2_eta_ScalarPtRank_cm"+label_+myVarSuffix_,Stop2_ScalarPtRank_cm.Eta());
         // others
-        tr.registerDerivedVar("MT2"+myVarSuffix_,MT2);
-        tr.registerDerivedVar("dR_Stop1Stop2"+myVarSuffix_,dR_Stop1Stop2);
-        tr.registerDerivedVar("dPhi_Stop1Stop2"+myVarSuffix_,dPhi_Stop1Stop2);
-        tr.registerDerivedVar("difference_stopMasses"+myVarSuffix_,difference_stopMasses);
-        tr.registerDerivedVar("average_stopMasses"+myVarSuffix_,average_stopMasses);
-        tr.registerDerivedVar("relativeDiff_stopMasses"+myVarSuffix_,relativeDiff_stopMasses);
-        tr.registerDerivedVar("Stop1ScalarPt_ScalarPtRank"+myVarSuffix_,Stop1ScalarPt_ScalarPtRank);
-        tr.registerDerivedVar("Stop2ScalarPt_ScalarPtRank"+myVarSuffix_,Stop2ScalarPt_ScalarPtRank);
+        tr.registerDerivedVar("MT2"+label_+myVarSuffix_,MT2);
+        tr.registerDerivedVar("dR_Stop1Stop2"+label_+myVarSuffix_,dR_Stop1Stop2);
+        tr.registerDerivedVar("dPhi_Stop1Stop2"+label_+myVarSuffix_,dPhi_Stop1Stop2);
+        tr.registerDerivedVar("difference_stopMasses"+label_+myVarSuffix_,difference_stopMasses);
+        tr.registerDerivedVar("average_stopMasses"+label_+myVarSuffix_,average_stopMasses);
+        tr.registerDerivedVar("relativeDiff_stopMasses"+label_+myVarSuffix_,relativeDiff_stopMasses);
+        tr.registerDerivedVar("Stop1ScalarPt_ScalarPtRank"+label_+myVarSuffix_,Stop1ScalarPt_ScalarPtRank);
+        tr.registerDerivedVar("Stop2ScalarPt_ScalarPtRank"+label_+myVarSuffix_,Stop2ScalarPt_ScalarPtRank);
     }
 
 public:    
-    MakeStopHemispheres(const std::string& jetName = "Jets", const std::string& jetMaskName = "GoodJets_pt45", const std::string& nJetName = "NGoodJets_pt45", const std::string& myVarSuffix = "", const Hemisphere::SeedMethod& seedMethod = Hemisphere::InvMassSeed)
+    MakeStopHemispheres(const std::string& jetName = "Jets", const std::string& jetMaskName = "GoodJets_pt45", const std::string& nJetName = "NGoodJets_pt45", const std::string& label = "", const std::string& myVarSuffix = "", const Hemisphere::SeedMethod& seedMethod = Hemisphere::InvMassSeed)
         : jetName_(jetName) 
         , jetMaskName_(jetMaskName)
         , nJetName_(nJetName)
+        , label_(label)
         , myVarSuffix_(myVarSuffix)
         , seedMethod_(seedMethod)
     {

--- a/Framework/include/MegaJetCombine.h
+++ b/Framework/include/MegaJetCombine.h
@@ -3,7 +3,6 @@
 
 #include <iostream>
 #include <algorithm>
-#include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
 
 class MegaJetCombine
 {

--- a/Framework/include/MegaJetCombine.h
+++ b/Framework/include/MegaJetCombine.h
@@ -71,17 +71,14 @@ private:
     
     void megaJetCombine(NTupleReader& tr) //Main function for using the list of combos to compute megajets
     {
-        //const auto& NGoodJets_pt30       = tr.getVar<int>("NGoodJets_pt30"+myVarSuffix_);
         const auto& Jets                 = tr.getVec<TLorentzVector>("Jets"+myVarSuffix_);
         const auto& GoodJets_pt30        = tr.getVec<bool>("GoodJets_pt30"+myVarSuffix_);
         const auto& GoodLeptons          = tr.getVec<std::pair<std::string,TLorentzVector>>("GoodLeptons"+myVarSuffix_);
         const auto& NGoodLeptons         = tr.getVar<int>("NGoodLeptons"+myVarSuffix_);
-        //const auto& GoodBJets_pt30       = tr.getVec<bool>("GoodBJets_pt30"+myVarSuffix_);
-        //const auto& NGoodBJets_pt30      = tr.getVar<int>("NGoodBJets_pt30"+myVarSuffix_);
         const auto& TwoLep_Mbl1_Idx      = tr.getVar<std::pair<unsigned int, unsigned int>>("TwoLep_Mbl1_Idx"+myVarSuffix_);
         const auto& TwoLep_Mbl2_Idx      = tr.getVar<std::pair<unsigned int, unsigned int>>("TwoLep_Mbl2_Idx"+myVarSuffix_);
-        const auto& MET                  = tr.getVar<double>("MET"+myVarSuffix_);
-        const auto& METPhi               = tr.getVar<double>("METPhi"+myVarSuffix_);
+        const auto& MET                  = tr.getVar<double>("MET");
+        const auto& METPhi               = tr.getVar<double>("METPhi");
 
         double massDiffThresh = 100; //specify threshold of mass difference between megajets to generate shortlist of candidates
         TLorentzVector lvMET;

--- a/Framework/include/MegaJetCombine.h
+++ b/Framework/include/MegaJetCombine.h
@@ -4,8 +4,6 @@
 #include <iostream>
 #include <algorithm>
 #include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
-#include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
-
 
 class MegaJetCombine
 {
@@ -157,7 +155,6 @@ private:
 
         FirstComboCandidates = RecoStopCands.first;
         SecComboCandidates = RecoStopCands.second;
-        asymm_mt2_lester_bisect::disableCopyrightMessage();
 
         tr.registerDerivedVar("RecoStop1"+myVarSuffix_, RecoStop1);
         tr.registerDerivedVar("RecoStop2"+myVarSuffix_, RecoStop2);

--- a/Framework/include/StopGenMatch.h
+++ b/Framework/include/StopGenMatch.h
@@ -1,7 +1,5 @@
 #ifndef STOPGENMATCH_H
 #define STOPGENMATCH_H
-#include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
-#include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
 
 // This class does gen matching to reconstruct the stops in an event both on gen level and reco level
 // In the event, that there are no stops e.g. in just ttbar+jets scenario, the "stop" should be close to the mass of the top
@@ -408,8 +406,6 @@ private:
             GM_Stop1_recphis = recPhiList.at(0);
             GM_Stop2_recphis = recPhiList.at(1);
 
-            asymm_mt2_lester_bisect::disableCopyrightMessage();
-            
             tr.registerDerivedVar("GM_StopMT2"+myVarSuffix_,        ttUtility::coreMT2calc(RecoSumList.at(0),RecoSumList.at(1),lvMET));
             tr.registerDerivedVar("GM_StopGenMT2"+myVarSuffix_,     ttUtility::coreMT2calc(GenSumList.at(0),GenSumList.at(1),lvGenMET));
             tr.registerDerivedVar("GM_Stop1"+myVarSuffix_,      RecoSumList.at(0));

--- a/Framework/include/StopJets.h
+++ b/Framework/include/StopJets.h
@@ -27,13 +27,10 @@ private:
     // -------------------------------------
     void getStopJets(NTupleReader& tr) const
     {
-        const auto* ttr                   = tr.getVar<TopTaggerResults*>("ttr");
-        const auto& Jets                  = tr.getVec<TLorentzVector>("Jets");
-        const auto& GoodJets_pt20         = tr.getVec<bool>("GoodJets_pt20");
-        //const auto& ISRmatched_dr_ptr     = tr.getVec<bool>("ISRmatched_dr_ptr");
-
+        const auto* ttr                   = tr.getVar<TopTaggerResults*>("ttr"+myVarSuffix_);
+        const auto& Jets                  = tr.getVec<TLorentzVector>("Jets"+myVarSuffix_);
+        const auto& GoodJets_pt20         = tr.getVec<bool>("GoodJets_pt20"+myVarSuffix_);
         auto& StopJets                    = tr.createDerivedVec<TLorentzVector>("StopJets"+myVarSuffix_);
-        //auto& ISRmatched_dr_ptr_maskedTop = tr.createDerivedVec<bool>("ISRmatched_dr_ptr_maskedTop"+myVarSuffix_);
  
         // --------------------------------- 
         // create an index for resolved tops
@@ -56,8 +53,6 @@ private:
                 // get top jets   
                 StopJets.push_back(top);
                 
-                // to filter the tops from ISR jets
-                //ISRmatched_dr_ptr_maskedTop.push_back(false);               
             }
         }
 
@@ -81,25 +76,11 @@ private:
             if ( std::find(usedIndex.begin(), usedIndex.end(), i) == usedIndex.end() ) 
             {
                 StopJets.push_back(Jets[i]);
-                //ISRmatched_dr_ptr_maskedTop.push_back(ISRmatched_dr_ptr[i]);
             }
         }
         auto& GoodStopJets = tr.createDerivedVec<bool>("GoodStopJets"+myVarSuffix_, StopJets.size(), true);
         tr.createDerivedVar<int>("NGoodStopJets"+myVarSuffix_, GoodStopJets.size());   
 
-        // ----------------------------------------------
-        // make filter to use inside hemispheres
-        //     -- remove the ISR jets inside GoodStopJets
-        // ----------------------------------------------     
-        //auto& GoodStopJets_maskedISR = tr.createDerivedVec<bool>("GoodStopJets_maskedISR"+myVarSuffix_, GoodStopJets.size(), false);
-        //for (unsigned int j = 0; j < GoodStopJets.size(); ++j)
-        //{
-        //    if (! (ISRmatched_dr_ptr_maskedTop[j]) ) 
-        //    {
-        //        GoodStopJets_maskedISR.at(j) = true;         
-        //    }
-        //}
-        //tr.createDerivedVar<int>("NGoodStopJets_maskedISR"+myVarSuffix_, GoodStopJets_maskedISR.size());        
     }
 
 public:    

--- a/Framework/include/StopJets.h
+++ b/Framework/include/StopJets.h
@@ -8,10 +8,6 @@
 #include "TopTagger/TopTagger/interface/TopObject.h"
 #include "TopTagger/TopTagger/interface/Constituent.h"
 
-// for gen level study
-#include "TopTagger/TopTagger/interface/TopTaggerUtilities.h"
-#include "TopTagger/TopTagger/interface/lester_mt2_bisect.h"
-
 #include "TLorentzVector.h"
 #include <iostream> 
 #include <vector>


### PR DESCRIPTION
It was brought to my attention while working on #254 that we should go through the different modules and make sure we are using `myVarSuffix_` everywhere it should be. This PR does just that and makes numerous spot fixes.

A notable change is how `MakeStopHemispheres` is instantiated. There is now an additional `label_` member variable that contains the information that _was_ being passed as `myVarSuffix_` i.e. containing "0l" or "1l" in all the output variable names etc. Thus, `myVarSuffix_` can then be used properly as it is used for all the other modules.

I have tested these changes with the `MakeNNVariables` analyzer, which utilizes many of the main modules.