### PR TITLE
Update DeepEventShape to Handle Multiple Regions in NN Cfg

### DIFF
--- a/Framework/include/DeepEventShape.h
+++ b/Framework/include/DeepEventShape.h
@@ -273,39 +273,38 @@ private:
             // Define and register deepESM bins
             const auto& NGoodJets = tr.getVar<int>(nJetVar_+myVarSuffix_);
             int iJet; // Iterator for simple edges coming from NN framework
-            int kJet; // Iterator for edges, boundaries coming from Validation
 
             // Determine how many unique parameters per Njet bin per region
-            int iSkip = binEdges_.size()          / (maxNJet_-minNJet_+1);
-            int kSkip = binEdgesPerRegion_.size() / (maxNJet_-minNJet_+1);
+            int iSkip = binEdges_.size() / (maxNJet_-minNJet_+1);
 
-            if      (NGoodJets <= minNJet_) {
+            if      (NGoodJets <= minNJet_)
                 iJet = 0;
-                kJet = 0;
-            }
-            else if (NGoodJets <= maxNJet_) {
+            else if (NGoodJets <= maxNJet_)
                 iJet = iSkip*(NGoodJets-minNJet_);
-                kJet = kSkip*(NGoodJets-minNJet_);
-            }
-            else if (NGoodJets  > maxNJet_) {
+            else if (NGoodJets  > maxNJet_)
                 iJet = iSkip*(maxNJet_-minNJet_);
-                kJet = kSkip*(maxNJet_-minNJet_);
-            }
 
             // Here, for edges from NN framework, two parameters are extracted for each Njets bin, ABCD region in the order:
             // disc1, disc2
             double disc1edge = binEdges_[iJet];
             double disc2edge = binEdges_[iJet+1];
 
+            // Discriminant 1 placed on horizontal axis
+            // Discriminant 2 placed on vertical axis
+
+            // Upper-right subregion
             bool passBinA = disc1 > disc1edge &&
                             disc2 > disc2edge;
 
+            // Upper-left subregion
             bool passBinB = disc1 < disc1edge &&
                             disc2 > disc2edge;
 
+            // Lower-right subregion
             bool passBinC = disc1 > disc1edge &&
                             disc2 < disc2edge;
 
+            // Lower-left subregion
             bool passBinD = disc1 < disc1edge &&
                             disc2 < disc2edge;
 
@@ -316,12 +315,23 @@ private:
             passVec.at(2) = passBinC;
             passVec.at(3) = passBinD;
 
+            int kJet; // Iterator for edges, boundaries coming from Validation
             for (const auto region : regions_) {
 
                 if (binEdgesPerRegion_.find(region) == binEdgesPerRegion_.end())
                     continue;
 
-                // Here, six parameters are extracted for each Njets bin, ABCD region in the order:
+                // Determine how many unique parameters per Njet bin per region
+                int kSkip = binEdgesPerRegion_[region].size() / (maxNJet_-minNJet_+1);
+
+                if      (NGoodJets <= minNJet_)
+                    kJet = 0;
+                else if (NGoodJets <= maxNJet_)
+                    kJet = kSkip*(NGoodJets-minNJet_);
+                else if (NGoodJets  > maxNJet_)
+                    kJet = kSkip*(maxNJet_-minNJet_);
+
+                // Here, six parameters are extracted for each (Njets bin, ABCD) region in the order:
                 // disc1, disc2, leftBoundary, rightBoundary, topBoundary, bottomBoundary
                 double disc1edge      = binEdgesPerRegion_[region][kJet];
                 double disc2edge      = binEdgesPerRegion_[region][kJet+1];
@@ -330,6 +340,9 @@ private:
                 double topBoundary    = binEdgesPerRegion_[region][kJet+4];
                 double bottomBoundary = binEdgesPerRegion_[region][kJet+5];
 
+                // Discriminant 1 placed on horizontal (left-to-right) axis
+                // Discriminant 2 placed on vertical (top-to-bottom) axis
+
                 // Check that the current event lives in the region in question.
                 // Otherwise, it cannot possibly live in any of the "A", "B", "C", "D" subregions.
                 bool withinBoundaries = disc1 > leftBoundary   &&
@@ -337,18 +350,22 @@ private:
                                         disc2 > bottomBoundary &&
                                         disc2 < topBoundary;
 
+                // Upper-right subregion
                 bool passBinA = disc1 > disc1edge &&
                                 disc2 > disc2edge &&
                                 withinBoundaries;
 
+                // Upper-left subregion
                 bool passBinB = disc1 < disc1edge &&
                                 disc2 > disc2edge &&
                                 withinBoundaries;
 
+                // Lower-right subregion
                 bool passBinC = disc1 > disc1edge &&
                                 disc2 < disc2edge &&
                                 withinBoundaries;
 
+                // Lower-left subregion
                 bool passBinD = disc1 < disc1edge &&
                                 disc2 < disc2edge &&
                                 withinBoundaries;

--- a/Framework/include/DeepEventShape.h
+++ b/Framework/include/DeepEventShape.h
@@ -202,6 +202,10 @@ private:
             firstEvent_ = false;
         }
 
+        auto& regions = tr.createDerivedVec<std::string>("regions_"+name_, regions_.size());
+        for (unsigned int i = 0; i < regions_.size(); i++)
+            regions.at(i) = regions_.at(i);
+
         //tensorflow status variable
         TF_Status* status = TF_NewStatus();
         
@@ -268,32 +272,93 @@ private:
           
             // Define and register deepESM bins
             const auto& NGoodJets = tr.getVar<int>(nJetVar_+myVarSuffix_);
-            int iJet;
-            if      (NGoodJets < minNJet_)                           iJet = 1;
-            else if (minNJet_ <= NGoodJets && NGoodJets <= maxNJet_) iJet = 2*(NGoodJets-minNJet_)+1;
-            else if (maxNJet_ < NGoodJets)                           iJet = 2*(maxNJet_-minNJet_)+1;
+            int iJet; // Iterator for simple edges coming from NN framework
+            int kJet; // Iterator for edges, boundaries coming from Validation
 
-            bool passBinA = disc1 > binEdges_[iJet-1] && disc2 > binEdges_[iJet];
-            bool passBinB = disc1 < binEdges_[iJet-1] && disc2 > binEdges_[iJet];
-            bool passBinC = disc1 > binEdges_[iJet-1] && disc2 < binEdges_[iJet];
-            bool passBinD = disc1 < binEdges_[iJet-1] && disc2 < binEdges_[iJet];
+            // Determine how many unique parameters per Njet bin per region
+            int iSkip = binEdges_.size()          / (maxNJet_-minNJet_+1);
+            int kSkip = binEdgesPerRegion_.size() / (maxNJet_-minNJet_+1);
 
-            tr.registerDerivedVar("DoubleDisCo_binA_"+name_+myVarSuffix_, passBinA);
-            tr.registerDerivedVar("DoubleDisCo_binB_"+name_+myVarSuffix_, passBinB);
-            tr.registerDerivedVar("DoubleDisCo_binC_"+name_+myVarSuffix_, passBinC);
-            tr.registerDerivedVar("DoubleDisCo_binD_"+name_+myVarSuffix_, passBinD);
+            if      (NGoodJets <= minNJet_) {
+                iJet = 0;
+                kJet = 0;
+            }
+            else if (NGoodJets <= maxNJet_) {
+                iJet = iSkip*(NGoodJets-minNJet_);
+                kJet = kSkip*(NGoodJets-minNJet_);
+            }
+            else if (NGoodJets  > maxNJet_) {
+                iJet = iSkip*(maxNJet_-minNJet_);
+                kJet = kSkip*(maxNJet_-minNJet_);
+            }
+
+            // Here, for edges from NN framework, two parameters are extracted for each Njets bin, ABCD region in the order:
+            // disc1, disc2
+            double disc1edge = binEdges_[iJet];
+            double disc2edge = binEdges_[iJet+1];
+
+            bool passBinA = disc1 > disc1edge &&
+                            disc2 > disc2edge;
+
+            bool passBinB = disc1 < disc1edge &&
+                            disc2 > disc2edge;
+
+            bool passBinC = disc1 > disc1edge &&
+                            disc2 < disc2edge;
+
+            bool passBinD = disc1 < disc1edge &&
+                            disc2 < disc2edge;
+
+            auto& passVec = tr.createDerivedVec<bool>("DoubleDisCo_"+name_+myVarSuffix_, 4);
+
+            passVec.at(0) = passBinA;
+            passVec.at(1) = passBinB;
+            passVec.at(2) = passBinC;
+            passVec.at(3) = passBinD;
 
             for (const auto region : regions_) {
 
-                bool passBinA = disc1 > binEdgesPerRegion_[region][iJet-1] && disc2 > binEdgesPerRegion_[region][iJet];
-                bool passBinB = disc1 < binEdgesPerRegion_[region][iJet-1] && disc2 > binEdgesPerRegion_[region][iJet];
-                bool passBinC = disc1 > binEdgesPerRegion_[region][iJet-1] && disc2 < binEdgesPerRegion_[region][iJet];
-                bool passBinD = disc1 < binEdgesPerRegion_[region][iJet-1] && disc2 < binEdgesPerRegion_[region][iJet];
+                if (binEdgesPerRegion_.find(region) == binEdgesPerRegion_.end())
+                    continue;
 
-                tr.registerDerivedVar("DoubleDisCo_binA_"+region+"_"+name_+myVarSuffix_, passBinA);
-                tr.registerDerivedVar("DoubleDisCo_binB_"+region+"_"+name_+myVarSuffix_, passBinB);
-                tr.registerDerivedVar("DoubleDisCo_binC_"+region+"_"+name_+myVarSuffix_, passBinC);
-                tr.registerDerivedVar("DoubleDisCo_binD_"+region+"_"+name_+myVarSuffix_, passBinD);
+                // Here, six parameters are extracted for each Njets bin, ABCD region in the order:
+                // disc1, disc2, leftBoundary, rightBoundary, topBoundary, bottomBoundary
+                double disc1edge      = binEdgesPerRegion_[region][kJet];
+                double disc2edge      = binEdgesPerRegion_[region][kJet+1];
+                double leftBoundary   = binEdgesPerRegion_[region][kJet+2];
+                double rightBoundary  = binEdgesPerRegion_[region][kJet+3];
+                double topBoundary    = binEdgesPerRegion_[region][kJet+4];
+                double bottomBoundary = binEdgesPerRegion_[region][kJet+5];
+
+                // Check that the current event lives in the region in question.
+                // Otherwise, it cannot possibly live in any of the "A", "B", "C", "D" subregions.
+                bool withinBoundaries = disc1 > leftBoundary   &&
+                                        disc1 < rightBoundary  && 
+                                        disc2 > bottomBoundary &&
+                                        disc2 < topBoundary;
+
+                bool passBinA = disc1 > disc1edge &&
+                                disc2 > disc2edge &&
+                                withinBoundaries;
+
+                bool passBinB = disc1 < disc1edge &&
+                                disc2 > disc2edge &&
+                                withinBoundaries;
+
+                bool passBinC = disc1 > disc1edge &&
+                                disc2 < disc2edge &&
+                                withinBoundaries;
+
+                bool passBinD = disc1 < disc1edge &&
+                                disc2 < disc2edge &&
+                                withinBoundaries;
+
+                auto& passVec = tr.createDerivedVec<bool>("DoubleDisCo_"+region+"_"+name_+myVarSuffix_, 4);
+
+                passVec.at(0) = passBinA;
+                passVec.at(1) = passBinB;
+                passVec.at(2) = passBinC;
+                passVec.at(3) = passBinD;
             }
         }
         else


### PR DESCRIPTION
--changes will allow the `DeepEventShape` module to get bin edges / boundaries for all regions defined in a neural network config file.

### Agreed Upon Specifications w/ @semrat ###
 * a new array called `regions` is intended to be added to the neural network `cfg` file, which lists as simple strings the name of the regions
 * an array of edges / boundaries per-Njets is to be provided for each region, where the name of the edges array is `binEdges_NAME`
 * the array of simple disc1, disc2 edges per-Njets coming directly from the neural network keep the same array name as before: `binEdges`
 * the array of edges for a region is a set of two edges defining the "ABCD" region and then four boundaries that contain the region for each Njets bin.
 * These edges / boundaries appear in the order:
 ```
disc1edge
disc2edge
leftBoundary
rightBoundary
topBoundary
bottomBoundary
 ```
 * a vector of `bool` corresponding if an event is in "A", "B", "C", or "D" for a given region is registered for use elsewhere in the code
