### PR TITLE
Remove Temporary Comment Out

### DIFF
--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -162,7 +162,7 @@ private:
         // proto baseline 
         bool passBaseline0l_pre = JetID                  &&
                                   passMETFilters         &&
-                                  //passMadHT              &&
+                                  passMadHT              &&
                                   passTrigger            &&
                                   passTriggerHadMC       &&
                                   (runtype != "Data"     || filetag.find("Data_JetHT") != std::string::npos) &&


### PR DESCRIPTION
--when making `TTJets_Incl` for NN inputs, don't veto with mad HT, but only temporary, so undo here.