### PR TITLE
updated the triggers for 0l channel

### DIFF
--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -457,6 +457,7 @@ private:
     {
         std::vector<std::string> mytriggers = {
             "HLT PFJet450",
+            //"HLT PFJet500",
             "HLT_PFHT900",
             "HLT_PFHT450_SixJet40_BTagCSV_p056",
             "HLT_PFHT400_SixJet30_DoubleBTagCSV_p056",            
@@ -468,10 +469,14 @@ private:
     {
         std::vector<std::string> mytriggers = {
             "HLT PFJet500",
+            //"HLT_PFJet550",
             "HLT_PFHT1050",
-            //"HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2",
+            "HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2",
             "HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2",
             "HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5",
+            // -- newer ones based on Semra's study
+            "HLT_PFHT380_SixJet32_DoubleBTagCSV_p075",
+            "HLT_PFHT430_SixJet40_BTagCSV_p080",
         };
         return PassTriggerGeneral(mytriggers,TriggerNames,TriggerPass);
     }
@@ -480,10 +485,15 @@ private:
     {
         std::vector<std::string> mytriggers = {
             "HLT PFJet500",
+            //"HLT_PFJet550",
             "HLT_PFHT1050",
-            //"HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2",
+            "HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2",
             "HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2",
             "HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5",
+            // -- newer ones based on Semra's study
+            "HLT PFHT430_SixPFJet40_PFBTagDeepCSV_1p5",
+            "HLT PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94",
+            "HLT PFHT450_SixPFJet36_PFBTagDeepCSV_1p59",
         };
         return PassTriggerGeneral(mytriggers,TriggerNames,TriggerPass);
     }


### PR DESCRIPTION
I just updated the list of hadronic triggers for each year.
You can see the details: https://indico.cern.ch/event/1029895/#7-semras-progress

**Note that**
1. **2016**: we don't include _**HLT_PFJet500**_  for not overlapping
   -- OR'd others based the run ranges
3. **2017**: we don't include _**HLT_PFJet550**_  for not overlapping
   -- OR'd others based the run ranges
5. **2018**: we don't include _**HLT_PFJet550**_  for not overlapping
   -- OR'd others based the run ranges

For more details, please look at this specific slides: https://indico.cern.ch/event/1029895/contributions/4324312/attachments/2228162/3859841/UL_Hadronic_Trigger_Lists.pdf
