### PR TITLE
Fix issue when running over 2018 UL ntuples

### DIFF
--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -72,7 +72,7 @@ private:
             passTriggerIsoMu = PassTriggerIsoMu2017(TriggerNames, TriggerPass);
             passTriggerMuonsRefAN = PassTriggerMuonsRefAN(TriggerNames, TriggerPass); 
         }
-        else if (runYear == "2018pre" || runYear == "2018post")
+        else if (runYear == "2018pre" || runYear == "2018post" || runYear == "2018")
         {
             passTriggerAllHad = PassTriggerAllHad2018(TriggerNames, TriggerPass); 
             passTriggerMuon = PassTriggerMuon2018(TriggerNames, TriggerPass);


### PR DESCRIPTION
- Adding in runYear "2018" in if statement for checking if an event passes trigger requirements