### PR TITLE
Fixing 2018 yearTag Bug in electron cut

### DIFF
--- a/Framework/include/Electron.h
+++ b/Framework/include/Electron.h
@@ -34,7 +34,7 @@ private:
         double ptCut = 0.0;
         if      (runYear.find("2016") != std::string::npos) ptCut = 30.0;
         else if (runYear == "2017") ptCut = 37.0; 
-        else if (runYear == "2018pre" || runYear == "2018post") ptCut = 37.0; 
+        else if (runYear == "2018pre" || runYear == "2018post" || runYear == "2018") ptCut = 37.0; 
         for(unsigned int iel = 0; iel < allElectrons.size(); ++iel)
         {
             utility::LorentzVector lvel = allElectrons.at(iel);


### PR DESCRIPTION
Year tag for 2018 was still only looking for pre and post. Now will check for "2018" as well