### PR TITLE
Moving to shape based correction btagSFs

### DIFF
--- a/Framework/src/BTagCalibrationStandalone.cc
+++ b/Framework/src/BTagCalibrationStandalone.cc
@@ -54,7 +54,9 @@ BTagEntry::BTagEntry(const std::string& csvLine)
     }
 
     // make parameters
-    char op = vec[0][0];
+    char op;
+    if(vec[0] == "shape") op = '3';
+    else op = vec[0][0];
     std::string check = "LMT3";
     if(check.find(op) == std::string::npos) 
     {


### PR DESCRIPTION
Added b-tag scale factors that are used for correcting the shape of the b-tag discriminator. See twiki link [here](https://twiki.cern.ch/twiki/bin/view/CMS/BTagShapeCalibration) for more info.

Changes:
- Added new scale factor calculation as described in the twiki page. Scale factor is calculated by taking the product of all shape-based corrections from the reshaping CSVs
- Shape based corrections are calculated using the `up_jes` and `down_jes` variations of the DeepCSV tagger discriminants