### PR TITLE
Fix Some Trigger Names for 0L

### DIFF
--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -469,7 +469,7 @@ private:
     bool PassTriggerAllHad2016(const std::vector<std::string>& TriggerNames, const std::vector<int>& TriggerPass)
     {
         std::vector<std::string> mytriggers = {
-            "HLT PFJet450",
+            "HLT_PFJet450",
             //"HLT PFJet500",
             "HLT_PFHT900",
             "HLT_PFHT450_SixJet40_BTagCSV_p056",
@@ -481,7 +481,7 @@ private:
     bool PassTriggerAllHad2017(const std::vector<std::string>& TriggerNames, const std::vector<int>& TriggerPass)
     {
         std::vector<std::string> mytriggers = {
-            "HLT PFJet500",
+            "HLT_PFJet500",
             //"HLT_PFJet550",
             "HLT_PFHT1050",
             "HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2",
@@ -497,16 +497,16 @@ private:
     bool PassTriggerAllHad2018(const std::vector<std::string>& TriggerNames, const std::vector<int>& TriggerPass) 
     {
         std::vector<std::string> mytriggers = {
-            "HLT PFJet500",
+            "HLT_PFJet500",
             //"HLT_PFJet550",
             "HLT_PFHT1050",
             "HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2",
             "HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2",
             "HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5",
             // -- newer ones based on Semra's study
-            "HLT PFHT430_SixPFJet40_PFBTagDeepCSV_1p5",
-            "HLT PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94",
-            "HLT PFHT450_SixPFJet36_PFBTagDeepCSV_1p59",
+            "HLT_PFHT430_SixPFJet40_PFBTagDeepCSV_1p5",
+            "HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94",
+            "HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59",
         };
         return PassTriggerGeneral(mytriggers,TriggerNames,TriggerPass);
     }


### PR DESCRIPTION
--a handful of trigger names for 0L were missing a `_` after the `HLT`, thus these triggers would never be found in the list or checked properly