### PR TITLE
Fix String Splitting Utility Function

### DIFF
--- a/Framework/src/Utility.cc
+++ b/Framework/src/Utility.cc
@@ -65,7 +65,7 @@ namespace utility
             std::string substr;
             std::getline(ss, substr, delim);
 
-            vs.push_back(string);
+            vs.push_back(substr);
         }
 
         return vs;


### PR DESCRIPTION
There is a bug in `Framework/src/Utility.cc` concerning the parsing of the trigger paths string [1].
The variable `substr` needs to be pushed back to the vector `vs` rather than `string` itself.
Thus, instead of making a vector of individual trigger path names, the entire concatenated list of trigger path names was being pushed back _n_ times.
The effect of this is that `passTrigger` like bools will always report as true...

[1] https://github.com/StealthStop/Framework/blob/master/Framework/src/Utility.cc#L56-L72