### PR TITLE
Fix Logic for Determining Sample Overlap

### DIFF
--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -117,8 +117,10 @@ private:
         {
             const auto& madHT  = tr.getVar<float>("madHT");
 
-            // Exclude events with MadGraph HT > 100 from the DY & WJets inclusive samples
-            if(filetag.find("DYJetsToLL_M-50_Incl") != std::string::npos && madHT > 100) passMadHT = false;
+            // Exclude events with MadGraph HT > 100 (70) from the WJets (DY) inclusive samples
+            // in order to avoid double counting with the HT-binned samples
+            // For DY, a special exception is made for 2016 and 2016APV where no HT-binned samples are present - 12 Oct 2022 JCH
+            if(filetag.find("DYJetsToLL_M-50_Incl") != std::string::npos && madHT > 70 && runYear.find("2016") == std::string::npos) passMadHT = false;
             if(filetag.find("WJetsToLNu_Incl") != std::string::npos      && madHT > 100) passMadHT = false;
 
             // Stitch TTbar samples together


### PR DESCRIPTION
The `passMadHT` boolean is used to veto events coming from an inclusive MadGraph sample (here concerned with DYJets and WJets) that would otherwise be counted/represented in a specific HT-binned sample. For WJets, the overlap occurs for `madHT > 100` and has not been changed, while for DYJets, the overlap threshold is now lowered to `madHT > 70` as we now have an HT-70to100 sample.

A special case is made for 2016preVFP and 2016postVFP, which are currently only represented by the inclusive MadGraph sample and no HT-binned ones. Thus, the `passMadHT` boolean is neutralized and made to stay `true` for any `madHT` for the 2016s.

**Care needs to be taken if/when the HT-binned samples are added for the 2016s.**