### PR TITLE
Template the DeltaR and DeltaPhi Functions

### DIFF
--- a/Framework/include/MakeMVAVariables.h
+++ b/Framework/include/MakeMVAVariables.h
@@ -74,7 +74,7 @@ private:
                 {
                     for(unsigned int ijet = 0; ijet < lv_all.size(); ijet++)
                     {
-                        double deltaR = utility::DeltaR(utility::convertLV<utility::LorentzVector, TLorentzVector>(d), lv_all.at(ijet) );
+                        double deltaR = utility::DeltaR(d, lv_all.at(ijet));
                         if(deltaR < 0.4)
                         {
                             if(numMatchedJets != 1 && genMatched) genMatched = megaJetID == jetCombo[ijet]; 

--- a/Framework/include/MakeMVAVariables.h
+++ b/Framework/include/MakeMVAVariables.h
@@ -74,7 +74,7 @@ private:
                 {
                     for(unsigned int ijet = 0; ijet < lv_all.size(); ijet++)
                     {
-                        double deltaR = utility::DeltaR(d, lv_all.at(ijet));
+                        double deltaR = utility::DeltaR(*d, lv_all.at(ijet));
                         if(deltaR < 0.4)
                         {
                             if(numMatchedJets != 1 && genMatched) genMatched = megaJetID == jetCombo[ijet]; 

--- a/Framework/include/Utility.h
+++ b/Framework/include/Utility.h
@@ -13,8 +13,8 @@ namespace utility
     typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>> LorentzVector;
     typedef ROOT::Math::Boost BoostVector;
 
-    double DeltaR(const LorentzVector& v1, const LorentzVector& v2);
-    double DeltaPhi(const LorentzVector& v1, const LorentzVector& v2);
+    //double DeltaR(const LorentzVector& v1, const LorentzVector& v2);
+    //double DeltaPhi(const LorentzVector& v1, const LorentzVector& v2);
     LorentzVector RotateZ(const LorentzVector& v, const double r);
     LorentzVector Boost(const LorentzVector& v, const BoostVector& b);
     const std::string color(const std::string& text, const std::string& color);
@@ -28,6 +28,18 @@ namespace utility
     template<typename T> T sum2(T v) { return v*v; }
     template<typename T, typename... Args> T sum2(T v, Args... args) { return v*v + sum2(args...); }
     template<typename T, typename... Args> T addInQuad(T v, Args... args) { return sqrt(sum2(v, args...)); }
+
+    template<typename LV1, typename LV2>
+    double DeltaR(const LV1& v1, const LV2& v2)
+    {
+        return ROOT::Math::VectorUtil::DeltaR(v1, v2);
+    }    
+
+    template<typename LV1, typename LV2>
+    double DeltaPhi(const LV1& v1, const LV2& v2)
+    {
+        return ROOT::Math::VectorUtil::DeltaPhi(v1, v2);
+    }    
 
     template<typename LV1, typename LV2>
     double calcMT(const LV1& lepton, const LV2& met)

--- a/Framework/include/Utility.h
+++ b/Framework/include/Utility.h
@@ -13,8 +13,6 @@ namespace utility
     typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>> LorentzVector;
     typedef ROOT::Math::Boost BoostVector;
 
-    //double DeltaR(const LorentzVector& v1, const LorentzVector& v2);
-    //double DeltaPhi(const LorentzVector& v1, const LorentzVector& v2);
     LorentzVector RotateZ(const LorentzVector& v, const double r);
     LorentzVector Boost(const LorentzVector& v, const BoostVector& b);
     const std::string color(const std::string& text, const std::string& color);

--- a/Framework/src/Utility.cc
+++ b/Framework/src/Utility.cc
@@ -5,16 +5,6 @@
 namespace utility
 {
 
-    //double DeltaR(const LorentzVector& v1, const LorentzVector& v2)
-    //{
-    //    return ROOT::Math::VectorUtil::DeltaR(v1, v2);
-    //}
-
-    //double DeltaPhi(const LorentzVector& v1, const LorentzVector& v2)
-    //{
-    //    return ROOT::Math::VectorUtil::DeltaPhi(v1, v2);
-    //}
-
     LorentzVector Boost(const LorentzVector& v, const BoostVector& b)
     {
         return ROOT::Math::VectorUtil::boost(v, b.BetaVector());

--- a/Framework/src/Utility.cc
+++ b/Framework/src/Utility.cc
@@ -5,15 +5,15 @@
 namespace utility
 {
 
-    double DeltaR(const LorentzVector& v1, const LorentzVector& v2)
-    {
-        return ROOT::Math::VectorUtil::DeltaR(v1, v2);
-    }
+    //double DeltaR(const LorentzVector& v1, const LorentzVector& v2)
+    //{
+    //    return ROOT::Math::VectorUtil::DeltaR(v1, v2);
+    //}
 
-    double DeltaPhi(const LorentzVector& v1, const LorentzVector& v2)
-    {
-        return ROOT::Math::VectorUtil::DeltaPhi(v1, v2);
-    }
+    //double DeltaPhi(const LorentzVector& v1, const LorentzVector& v2)
+    //{
+    //    return ROOT::Math::VectorUtil::DeltaPhi(v1, v2);
+    //}
 
     LorentzVector Boost(const LorentzVector& v, const BoostVector& b)
     {


### PR DESCRIPTION
For flexibility, template the `DeltaR` and `DeltaPhi` functions in `Utility` so that we do not have to think about if a vector is a `TLorentzVector` or a `LorentzVector`, they both implement, the `Phi` and `Eta` methods.