### PR TITLE
NN Output Locations Change

### DIFF
--- a/Framework/include/DeepEventShape.h
+++ b/Framework/include/DeepEventShape.h
@@ -270,7 +270,7 @@ private:
         // Register Variables and determine which regions/subregions an event is
         // based on inferencing with the Double DisCo NN
         double disc1   = discriminators[0][0];
-        double disc2   = discriminators[0][2];
+        double disc2   = discriminators[0][1];
         double massReg = discriminators[1][0];
         tr.registerDerivedVar("DoubleDisCo_disc1_"+name_+myVarSuffix_, disc1);
         tr.registerDerivedVar("DoubleDisCo_disc2_"+name_+myVarSuffix_, disc2);


### PR DESCRIPTION
With the latest training procedure (i.e. for the v2.0-tagged Double DisCo trainings for 0L and 1L), disc1 and disc2 are no longer at the 0th and 2nd index of the length four output vector. They are now at the 0th and 1st index, respectively. Please see @cros0400 for more details.