### PR TITLE
WIP: Analysis Performance Enhancements

### DIFF
--- a/Framework/include/BTagCorrector.h
+++ b/Framework/include/BTagCorrector.h
@@ -536,7 +536,9 @@ public:
     //Operator
     void operator()(NTupleReader& tr)
     {
-        registerVarToNTuples(tr);
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
+        if (!lostCauseEvent)
+            registerVarToNTuples(tr);
     }
 
     //member variables

--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -151,10 +151,12 @@ private:
         bool passMETFilters  = globalSuperTightHalo2016Filter && PrimaryVertexFilter && BadPFMuonFilter && EcalDeadCellTriggerPrimitiveFilter && HBHEIsoNoiseFilter && HBHENoiseFilter;
 
         // With fast mode *off* (false), every event is considered and processed by all modules
-        // If fast mode is active (true), an event must "earn" its importance by passing any of 
-        // the main 0L, 1L, 2L baselines. If it does not, time-intensive modules can be skipped
-        // in the pipeline as long as the analyzer is also informed and also skips to next event
+        // in the pipeline. If fast mode is active (true), an event must "earn" its keep by passing any of 
+        // the main 0L, 1L, 2L baselines. If an event does not pass any of these main selections, time-intensive
+        // modules can be skipped in the pipeline as long as the relevant analyzer is also informed and also skips to the next event
         const auto& fastMode = tr.getVar<bool>("fastMode");
+
+        // If fastMode is false, then an event is never a "lost cause", implying it will go through the entire module pipeline
         bool lostCauseEvent = fastMode;
                 
         // -----------------------------------
@@ -338,12 +340,13 @@ private:
         bool pass_qcdCR_1b_1t = pass_qcdCR && NGoodBJets_pt30 >= 1  && ntops >= 1;
         bool pass_qcdCR_2b    = pass_qcdCR && NGoodBJets_pt30 >= 2;
 
-        // Now combine all relevant baselines into single bool
-        // Or in any useful event-level booleans
-        lostCauseEvent &= !passBaseline0l_Good_noHEMveto &&
-                          !passBaseline1l_Good_noHEMveto &&
-                          !passBaseline2l_Good_noHEMveto &&
-                          !pass_qcdCR                     ;
+        // Now combine all relevant baselines into a single bool
+        // Here we select the main baselines for all three channels
+        // If all four booleans are false, then the event is considered a "lost cause"
+        lostCauseEvent &= !passBaseline0l_Good &&
+                          !passBaseline1l_Good &&
+                          !passBaseline2l_Good &&
+                          !pass_qcdCR           ;
 
         // -------------------
         // Register all things

--- a/Framework/include/DeepEventShape.h
+++ b/Framework/include/DeepEventShape.h
@@ -196,7 +196,7 @@ private:
             const auto& runYear = tr.getVar<std::string>("runYear");
             try
             {                
-                if(runYear != year_)
+                if(runYear != year_ and year_ != "Run2")
                 {
                     throw "Warning: using DeepESM config file with \""+year_+"\" year but expected \""+runYear+"\" year";
                 }
@@ -431,7 +431,9 @@ public:
     
     void operator()(NTupleReader& tr)
     {
-        runDeepEventShape(tr);
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
+        if (!lostCauseEvent)
+            runDeepEventShape(tr);
     }
 };
 

--- a/Framework/include/MakeMVAVariables.h
+++ b/Framework/include/MakeMVAVariables.h
@@ -233,7 +233,8 @@ private:
 
         double phiMax = (NGoodJets > 0) ? Jets_cm_psort[0].tlv.Phi() : 0.0;
 
-        utility::LorentzVector combinedJetTLV;
+        utility::LorentzVector combinedNthJetTLV;
+        utility::LorentzVector combinedN1thJetTLV;
         for(unsigned int ji=0; ji<cm_jets.size(); ji++ ) 
         {
             utility::LorentzVector Jet_cm_psort = Jets_cm_psort.at(ji).tlv;                
@@ -267,18 +268,25 @@ private:
             }
 
             // Add all jets after and including the nth jet (ji >= n-1)
-            if ( ji >= nTopJets_-1 )
-            {
-                combinedJetTLV += Jet_cm_psort;
-            }
+            if      ( ji >= nTopJets_-2 )
+                combinedN1thJetTLV += Jet_cm_psort;
+            else if ( ji >= nTopJets_-1 )
+                combinedNthJetTLV += Jet_cm_psort;
         } // ji
 
-        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_pt_cm"+channel_+myVarSuffix_,       static_cast<double>(combinedJetTLV.Pt())    );
-        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_ptrHT_cm"+channel_+myVarSuffix_,    static_cast<double>(combinedJetTLV.Pt() / HT_Trigger_pt30)    );
-        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_eta_cm"+channel_+myVarSuffix_,      static_cast<double>(combinedJetTLV.Eta())   );
-        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_phi_cm"+channel_+myVarSuffix_,      static_cast<double>(combinedJetTLV.Phi())   );
-        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_m_cm"+channel_+myVarSuffix_,        static_cast<double>(combinedJetTLV.M())     );
-        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_E_cm"+channel_+myVarSuffix_,    static_cast<double>(combinedJetTLV.E())     );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_-1) + "thToLast"+MVAJetName_+"_pt_cm"+channel_+myVarSuffix_,    static_cast<double>(combinedN1thJetTLV.Pt())    );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_-1) + "thToLast"+MVAJetName_+"_ptrHT_cm"+channel_+myVarSuffix_, static_cast<double>(combinedN1thJetTLV.Pt() / HT_Trigger_pt30)    );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_-1) + "thToLast"+MVAJetName_+"_eta_cm"+channel_+myVarSuffix_,   static_cast<double>(combinedN1thJetTLV.Eta())   );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_-1) + "thToLast"+MVAJetName_+"_phi_cm"+channel_+myVarSuffix_,   static_cast<double>(combinedN1thJetTLV.Phi())   );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_-1) + "thToLast"+MVAJetName_+"_m_cm"+channel_+myVarSuffix_,     static_cast<double>(combinedN1thJetTLV.M())     );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_-1) + "thToLast"+MVAJetName_+"_E_cm"+channel_+myVarSuffix_,     static_cast<double>(combinedN1thJetTLV.E())     );
+
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_pt_cm"+channel_+myVarSuffix_,    static_cast<double>(combinedNthJetTLV.Pt())    );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_ptrHT_cm"+channel_+myVarSuffix_, static_cast<double>(combinedNthJetTLV.Pt() / HT_Trigger_pt30)    );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_eta_cm"+channel_+myVarSuffix_,   static_cast<double>(combinedNthJetTLV.Eta())   );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_phi_cm"+channel_+myVarSuffix_,   static_cast<double>(combinedNthJetTLV.Phi())   );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_m_cm"+channel_+myVarSuffix_,     static_cast<double>(combinedNthJetTLV.M())     );
+        tr.registerDerivedVar("combined" + std::to_string(nTopJets_) + "thToLast"+MVAJetName_+"_E_cm"+channel_+myVarSuffix_,     static_cast<double>(combinedNthJetTLV.E())     );
 
         auto GoodLeptons_cm = std::make_unique<std::vector<utility::LorentzVector>>();
         for(unsigned int ilep = 0; ilep < GoodLeptons.size(); ilep++)
@@ -358,11 +366,11 @@ private:
         double fwm3_top6    = esv_top6.getFWmoment( 3 )  ;
         double fwm4_top6    = esv_top6.getFWmoment( 4 )  ;
         double fwm5_top6    = esv_top6.getFWmoment( 5 )  ;
-        double fwm6_top6    = esv_top6.getFWmoment( 6 )  ;
-        double fwm7_top6    = esv_top6.getFWmoment( 7 )  ;
-        double fwm8_top6    = esv_top6.getFWmoment( 8 )  ;
-        double fwm9_top6    = esv_top6.getFWmoment( 9 )  ;
-        double fwm10_top6   = esv_top6.getFWmoment( 10 ) ;
+        double fwm6_top6    = esv_top6.getFWmoment( 5)  ;
+        double fwm7_top6    = esv_top6.getFWmoment( 5)  ;
+        double fwm8_top6    = esv_top6.getFWmoment( 5)  ;
+        double fwm9_top6    = esv_top6.getFWmoment( 5)  ;
+        double fwm10_top6   = esv_top6.getFWmoment( 5 ) ;
         double jmt_ev0_top6 = eigen_vals_norm_top6[0]    ;
         double jmt_ev1_top6 = eigen_vals_norm_top6[1]    ;
         double jmt_ev2_top6 = eigen_vals_norm_top6[2]    ;
@@ -510,7 +518,9 @@ public:
 
     void operator()(NTupleReader& tr)
     {
-        makeMVAVariables(tr);
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
+        if (!lostCauseEvent)
+            makeMVAVariables(tr);
     }
 };
 

--- a/Framework/include/MakeMVAVariables.h
+++ b/Framework/include/MakeMVAVariables.h
@@ -362,18 +362,18 @@ private:
         EventShapeVariables esv_top6( cm_jets_top6 ) ;
         TVectorD eigen_vals_norm_top6 = esv_top6.getEigenValues() ;
 
-        double fwm2_top6    = esv_top6.getFWmoment( 2 )  ;
-        double fwm3_top6    = esv_top6.getFWmoment( 3 )  ;
-        double fwm4_top6    = esv_top6.getFWmoment( 4 )  ;
-        double fwm5_top6    = esv_top6.getFWmoment( 5 )  ;
-        double fwm6_top6    = esv_top6.getFWmoment( 5)  ;
-        double fwm7_top6    = esv_top6.getFWmoment( 5)  ;
-        double fwm8_top6    = esv_top6.getFWmoment( 5)  ;
-        double fwm9_top6    = esv_top6.getFWmoment( 5)  ;
-        double fwm10_top6   = esv_top6.getFWmoment( 5 ) ;
-        double jmt_ev0_top6 = eigen_vals_norm_top6[0]    ;
-        double jmt_ev1_top6 = eigen_vals_norm_top6[1]    ;
-        double jmt_ev2_top6 = eigen_vals_norm_top6[2]    ;
+        double fwm2_top6    = esv_top6.getFWmoment( 2 ) ;
+        double fwm3_top6    = esv_top6.getFWmoment( 3 ) ;
+        double fwm4_top6    = esv_top6.getFWmoment( 4 ) ;
+        double fwm5_top6    = esv_top6.getFWmoment( 5 ) ;
+        double fwm6_top6    = esv_top6.getFWmoment( 6 ) ;
+        double fwm7_top6    = esv_top6.getFWmoment( 7 ) ;
+        double fwm8_top6    = esv_top6.getFWmoment( 8 ) ;
+        double fwm9_top6    = esv_top6.getFWmoment( 9 ) ;
+        double fwm10_top6   = esv_top6.getFWmoment( 10) ;
+        double jmt_ev0_top6 = eigen_vals_norm_top6[0]   ;
+        double jmt_ev1_top6 = eigen_vals_norm_top6[1]   ;
+        double jmt_ev2_top6 = eigen_vals_norm_top6[2]   ;
 
         // Register Variables
         for(unsigned int i = 0; i < nTopJets_; i++)

--- a/Framework/include/MakeStopHemispheres.h
+++ b/Framework/include/MakeStopHemispheres.h
@@ -233,7 +233,9 @@ public:
 
     void operator()(NTupleReader& tr)
     {
-        getHemispheres(tr);
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
+        if (!lostCauseEvent)
+            getHemispheres(tr);
     }
 };
 

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -853,7 +853,9 @@ public:
 
     void operator()(NTupleReader& tr)
     {
-        scaleFactors(tr);
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
+        if (!lostCauseEvent)
+            scaleFactors(tr);
     }
 };
 

--- a/Framework/include/StopGenMatch.h
+++ b/Framework/include/StopGenMatch.h
@@ -446,7 +446,9 @@ public:
 
     void operator()(NTupleReader& tr)
     {
-        genMatch(tr);
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
+        if (!lostCauseEvent)
+            genMatch(tr);
     }
 };
 

--- a/Framework/include/StopJets.h
+++ b/Framework/include/StopJets.h
@@ -87,7 +87,9 @@ public:
 
     void operator()(NTupleReader& tr)
     {
-        getStopJets(tr);
+        const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
+        if (!lostCauseEvent)
+            getStopJets(tr);
     }
 };
 


### PR DESCRIPTION
Add logic (off by default) that lets a stack of modules be skipped while processing an event. This logic considers the "worthiness" of an event i.e. does it satisfy _any_ of the three channels' SR or CR, where an unworthy event can lead to skipping to the end of the module pipeline and avoiding "wasted" time in the most computationally-intensive modules. The decision can be controlled by the command line option `-s`, which stores the boolean `fastMode` and toggles the behavior on. For `AnalyzeDoubleDisCo` (the target analyzer module for this) it can lead to a 200-250% speed up (based on running on 100k 2018_TT events). I have done a cross comparison of `AnalyzeDoubleDisCo` output with and without the fast mode on and see identical results. However, for TopSeed Stop 4-vectors, I see a peculiar 1-in-100k effect, where the kinematics of the stops differ slightly.

--add noHEMveto version of 2L baseline for completeness.
--tell `DeepEventShape` that it is okay if a NN config is for year "Run2" to quiet warnings.
--in `MakeMVAVariables` create 7th and 6th combined jet object.