### PR TITLE
Handle Data Set Names Containing "_skim"

### DIFF
--- a/Framework/include/BTagCorrector.h
+++ b/Framework/include/BTagCorrector.h
@@ -66,6 +66,17 @@ public:
         if(suffix.size())
         {
             std::string suffix2 = suffix;
+
+            // If we run on a skim data set, there is probably a _skim
+            // at the end of the name, so scrape it off before trying
+            // to get the beff histograms
+            std::string scrapeOff = "_skim";
+            const size_t position = suffix2.find(scrapeOff);
+            if(position != std::string::npos)
+            {
+                suffix2.erase(position, scrapeOff.length());
+            }
+
             h_eff_b.reset( (TH2F*)file.Get(("n_eff_b_" + suffix2).c_str()) );
             
             if(!h_eff_b.get())

--- a/Framework/include/BTagCorrector.h
+++ b/Framework/include/BTagCorrector.h
@@ -67,9 +67,9 @@ public:
         {
             std::string suffix2 = suffix;
 
-            // If we run on a skim data set, there is probably a _skim
+            // If we run on a skim data set, there should be a "_skim" suffix
             // at the end of the name, so scrape it off before trying
-            // to get the beff histograms
+            // to get the btag eff histograms
             std::string scrapeOff = "_skim";
             const size_t position = suffix2.find(scrapeOff);
             if(position != std::string::npos)


### PR DESCRIPTION
To accommodate sample set names with "_skim" in them, the `BTagCorrector` needs to simply chop off the `_skim` suffix when looking for a btag efficiency histogram and use the "nominal" histogram for the given sample.