### PR TITLE
Handle TriggerPass Branch Title

### DIFF
--- a/Framework/include/MiniTupleMaker.h
+++ b/Framework/include/MiniTupleMaker.h
@@ -28,10 +28,13 @@ public:
     void initBranches(const NTupleReader&);
 
     void fill();
+    void fill(const NTupleReader&);
 
 private:
     TFile* const file_;
     TTree* const tree_;
+
+    bool startedFilling_ = false;
 
     std::set<std::string> tupleVars_;
 
@@ -52,6 +55,7 @@ private:
     template<typename T> void prepVec(const NTupleReader& tr, const std::string& name)
     {
         TBranch *tb = tree_->GetBranch(name.c_str());
+
         if(!tb) tree_->Branch(name.c_str(), static_cast<std::vector<T>**>(const_cast<void*>(tr.getVecPtr<T>(name))));
         else       tb->SetAddress(const_cast<void*>(tr.getVecPtr<T>(name)));
     }

--- a/Framework/src/MiniTupleMaker.cc
+++ b/Framework/src/MiniTupleMaker.cc
@@ -82,3 +82,18 @@ void MiniTupleMaker::fill()
 {
     tree_->Fill();
 }
+
+void MiniTupleMaker::fill(const NTupleReader& tr)
+{
+    tree_->Fill();
+
+    // Special case fill to ensure we have a good pointer to the branches
+    // The title of the TriggerPass branch needs to be set to the same title
+    // coming from the ntuples, which is a concatenated string of trigger paths---useful !
+    // This title is unfortunately not passed on automatically when init'ing the branch
+    if (!startedFilling_)
+    {
+        tree_->GetBranch("TriggerPass")->SetTitle(tr.getBranchTitle("TriggerPass").c_str());
+        startedFilling_ = true;
+    }
+}


### PR DESCRIPTION
The names of the trigger paths, whose results are stored in the `vector<int>` `TriggerPass` branch, are put into a concatenated string that is set as the title of the `TriggerPass` branch itself. When running `MiniTupleMaker`, this title is not automatically passed on to the branch in the new TTree. So here we explicitly set that title in an exceptional case. It seems we have to do the title setting *after* we have filled at least once, otherwise we will be trying to set a title with a `void*` pointer...