### PR TITLE
Tops and PuID

### DIFF
--- a/Framework/include/Jet.h
+++ b/Framework/include/Jet.h
@@ -1,8 +1,11 @@
 #ifndef JET_H
 #define JET_H
 
-inline bool passesPuIdMedium(float pt, float eta, float disc_value, std::string runYear){
-     constexpr float cuts[2][4][4] = {
+class Jet
+{
+private:
+    std::string myVarSuffix_;
+    const float puIDcut_medium[2][4][4]= {
         {{ 0.20,-0.56,-0.43,-0.38},
         { 0.62,-0.39,-0.32,-0.29},
         { 0.86,-0.10,-0.15,-0.08},
@@ -12,23 +15,7 @@ inline bool passesPuIdMedium(float pt, float eta, float disc_value, std::string 
         {0.90,0.36,-0.16,-0.09},
         {0.96,0.61,0.14,0.12}}
     };
-    int yearidx = 0;
-    if (runYear.find("2016") == std::string::npos) yearidx = 1;
-    int ptidx = 0;
-    int etaidx = 0;
-    if( pt < 20) ptidx = 0;
-    else if( pt < 30) ptidx = 1;
-    else if( pt < 40) ptidx = 2;
-    else if( pt < 50) ptidx = 3;
-    if( std::abs(eta) < 2.5f) etaidx = 0;
-    else if( std::abs(eta) < 2.75f) etaidx = 1;
-    else if( std::abs(eta) < 3.0f) etaidx = 2;
-    else if( std::abs(eta) < 5.0f) etaidx = 3;
-    return cuts[yearidx][ptidx][etaidx] < disc_value || pt > 50.0f;
-}
-
-inline bool passesPuIdTight(float pt, float eta, float disc_value, std::string runYear){
-     constexpr float cuts[2][4][4] = {
+    const float puIDcut_tight[2][4][4] = {
         {{ 0.71,-0.32,-0.30,-0.22},
         { 0.87,-0.08,-0.16,-0.12},
         { 0.94,-0.24,0.05,0.10},
@@ -38,25 +25,22 @@ inline bool passesPuIdTight(float pt, float eta, float disc_value, std::string r
         {0.96,0.82,0.20,0.09},
         {0.98,0.92,0.47,0.29}}
     };
-    int yearidx = 0;
-    if (runYear.find("2016") == std::string::npos) yearidx = 1;
-    int ptidx = 0;
-    int etaidx = 0;
-    if( pt < 20) ptidx = 0;
-    else if( pt < 30) ptidx = 1;
-    else if( pt < 40) ptidx = 2;
-    else if( pt < 50) ptidx = 3;
-    if( std::abs(eta) < 2.5f) etaidx = 0;
-    else if( std::abs(eta) < 2.75f) etaidx = 1;
-    else if( std::abs(eta) < 3.0f) etaidx = 2;
-    else if( std::abs(eta) < 5.0f) etaidx = 3;
-    return cuts[yearidx][ptidx][etaidx] < disc_value || pt > 50.0f;
-}
 
-class Jet
-{
-private:
-    std::string myVarSuffix_;
+    bool passPuID(float pt, float eta, float disc_value, std::string runYear, const float cuts[2][4][4]){
+        int yearidx = 0;
+        if (runYear.find("2016") == std::string::npos) yearidx = 1;
+        int ptidx = 0;
+        int etaidx = 0;
+        if( pt < 20) ptidx = 0;
+        else if( pt < 30) ptidx = 1;
+        else if( pt < 40) ptidx = 2;
+        else if( pt < 50) ptidx = 3;
+        if( std::abs(eta) < 2.5f) etaidx = 0;
+        else if( std::abs(eta) < 2.75f) etaidx = 1;
+        else if( std::abs(eta) < 3.0f) etaidx = 2;
+        else if( std::abs(eta) < 5.0f) etaidx = 3;
+        return cuts[yearidx][ptidx][etaidx] < disc_value || pt > 50.0f;
+    }
 
     void setJetVar(bool pass, std::vector<bool>& boolVec, int& n)
     {
@@ -173,8 +157,8 @@ private:
         {               
             utility::LorentzVector lv = Jets.at(i);
          
-            bool puID_medium = passesPuIdMedium(lv.Pt(), lv.Eta(), puId.at(i), runYear);
-            bool puID_tight  = passesPuIdTight(lv.Pt(), lv.Eta(), puId.at(i), runYear);
+            bool puID_medium = passPuID(lv.Pt(), lv.Eta(), puId.at(i), runYear, puIDcut_medium);
+            bool puID_tight  = passPuID(lv.Pt(), lv.Eta(), puId.at(i), runYear, puIDcut_tight);
   
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 20, jets_pt20_, NJets_pt20); 
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 30, jets_pt30_, NJets_pt30);

--- a/Framework/include/Jet.h
+++ b/Framework/include/Jet.h
@@ -1,13 +1,19 @@
 #ifndef JET_H
 #define JET_H
 
-inline bool passesPuIdMedium(float pt, float eta, float disc_value){
-     constexpr float cuts[4][4] = {
-        { 0.20,-0.56,-0.43,-0.38},
+inline bool passesPuIdMedium(float pt, float eta, float disc_value, std::string runYear){
+     constexpr float cuts[2][4][4] = {
+        {{ 0.20,-0.56,-0.43,-0.38},
         { 0.62,-0.39,-0.32,-0.29},
         { 0.86,-0.10,-0.15,-0.08},
-        { 0.93,0.19,0.04,0.12}
+        { 0.93,0.19,0.04,0.12}},
+        {{0.26,-0.33,-0.54,-0.37},
+        {0.68,-0.04,-0.43,-0.30},
+        {0.90,0.36,-0.16,-0.09},
+        {0.96,0.61,0.14,0.12}}
     };
+    int yearidx = 0;
+    if (runYear.find("2016") == std::string::npos) yearidx = 1;
     int ptidx = 0;
     int etaidx = 0;
     if( pt < 20) ptidx = 0;
@@ -18,7 +24,33 @@ inline bool passesPuIdMedium(float pt, float eta, float disc_value){
     else if( std::abs(eta) < 2.75f) etaidx = 1;
     else if( std::abs(eta) < 3.0f) etaidx = 2;
     else if( std::abs(eta) < 5.0f) etaidx = 3;
-    return cuts[ptidx][etaidx] < disc_value || pt > 50.0f;
+    return cuts[yearidx][ptidx][etaidx] < disc_value || pt > 50.0f;
+}
+
+inline bool passesPuIdTight(float pt, float eta, float disc_value, std::string runYear){
+     constexpr float cuts[2][4][4] = {
+        {{ 0.71,-0.32,-0.30,-0.22},
+        { 0.87,-0.08,-0.16,-0.12},
+        { 0.94,-0.24,0.05,0.10},
+        { 0.97,0.48,0.26,0.29}},
+        {{0.77,0.38,-0.31,-0.21},
+        {0.90,0.60,-0.12,-0.13},
+        {0.96,0.82,0.20,0.09},
+        {0.98,0.92,0.47,0.29}}
+    };
+    int yearidx = 0;
+    if (runYear.find("2016") == std::string::npos) yearidx = 1;
+    int ptidx = 0;
+    int etaidx = 0;
+    if( pt < 20) ptidx = 0;
+    else if( pt < 30) ptidx = 1;
+    else if( pt < 40) ptidx = 2;
+    else if( pt < 50) ptidx = 3;
+    if( std::abs(eta) < 2.5f) etaidx = 0;
+    else if( std::abs(eta) < 2.75f) etaidx = 1;
+    else if( std::abs(eta) < 3.0f) etaidx = 2;
+    else if( std::abs(eta) < 5.0f) etaidx = 3;
+    return cuts[yearidx][ptidx][etaidx] < disc_value || pt > 50.0f;
 }
 
 class Jet
@@ -51,6 +83,7 @@ private:
         const auto& NElectrons    = tr.getVar<int>("NGoodElectrons"+myVarSuffix_);
         const auto& NonIsoMuons   = tr.getVec<bool>("NonIsoMuons"+myVarSuffix_);
         const auto& puId          = tr.getVec<float>("Jets"+myVarSuffix_+"_pileupId");
+        const auto& runYear       = tr.getVar<std::string>("runYear");
 
         //Adding code to create a vector of GoodJets -> defined as the jet collection that eliminates the closest jet to any good lepton (muon or electron) 
         //if that delta R is less than 0.4 and the pT of the jet and lepton is approximately the same
@@ -139,10 +172,13 @@ private:
         for(unsigned int i = 0; i < Jets.size(); ++i ) 
         {               
             utility::LorentzVector lv = Jets.at(i);
-           
+         
+            bool puID_medium = passesPuIdMedium(lv.Pt(), lv.Eta(), puId.at(i), runYear);
+            bool puID_tight  = passesPuIdTight(lv.Pt(), lv.Eta(), puId.at(i), runYear);
+  
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 20, jets_pt20_, NJets_pt20); 
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 30, jets_pt30_, NJets_pt30);
-            setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 30 && passesPuIdMedium(lv.Pt(), lv.Eta(), puId.at(i)) , jets_puID_, NJets_puID);
+            setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 30 && puID_medium, jets_puID_, NJets_puID);
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 40, jets_pt40_, NJets_pt40);
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 45, jets_pt45_, NJets_pt45);
 
@@ -151,7 +187,7 @@ private:
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 30 && goodjets_.at(i), goodjets_pt30_, NGoodJets_pt30);
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 40 && goodjets_.at(i), goodjets_pt40_, NGoodJets_pt40);
             setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 45 && goodjets_.at(i), goodjets_pt45_, NGoodJets_pt45);
-            setJetVar( abs(lv.Eta()) < etaCut && passesPuIdMedium(lv.Pt(), lv.Eta(), puId.at(i)) && lv.Pt() > 10 && goodjets_.at(i),
+            setJetVar( abs(lv.Eta()) < etaCut && lv.Pt() > 10 && puID_medium && goodjets_.at(i),
                     goodjets_puID_, NGoodJetsPuIdMedium );
 
             setJetVar( abs(lv.Eta()) < etaCut &&             tempNonIsoMuonJets->at(i), nonIsoMuonjets_,      NNonIsoMuonJets     );

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -660,8 +660,8 @@ private:
         auto* topPtVec          = new std::vector<float>();
         if( filetag.find("TTTo") != std::string::npos )
         {
-            const double a=0.0615, b=-0.0005;
-            auto SF = [&](const double pt){return exp(a + b * pt);};
+            const double a=0.103, b=-0.0118, c=-0.000134, d=0.973;
+            auto SF = [&](const double pt){return a * exp(b * x) + c * x + d;};
             
             const auto& GenParticles        = tr.getVec<utility::LorentzVector>("GenParticles");
             const auto& GenParticles_PdgId  = tr.getVec<int>("GenParticles_PdgId"             );

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -661,7 +661,7 @@ private:
         if( filetag.find("TTTo") != std::string::npos )
         {
             const double a=0.103, b=-0.0118, c=-0.000134, d=0.973;
-            auto SF = [&](const double pt){return a * exp(b * x) + c * x + d;};
+            auto SF = [&](const double pt){return a * exp(b * pt) + c * pt + d;};
             
             const auto& GenParticles        = tr.getVec<utility::LorentzVector>("GenParticles");
             const auto& GenParticles_PdgId  = tr.getVec<int>("GenParticles_PdgId"             );

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -712,7 +712,7 @@ private:
         const auto& NNonIsoMuons      = tr.getVar<int>("NNonIsoMuons"                        +myVarSuffix_);
         double totalEventWeight       = -1.0;
 
-        double commonWeight = Weight * FinalLumi * bTagWeight * prefiringScaleFactor * puWeightCorr;
+        double commonWeight = Weight * FinalLumi * bTagWeight * prefiringScaleFactor * puWeightCorr * topPtScaleFactor;
         tr.registerDerivedVar("CommonWeight" + myVarSuffix_, commonWeight);
 
         // 0-Lepton


### PR DESCRIPTION
- Reverting to the NNLO / NLO top pt reweighing scheme
- Adding in pileup ID tight function 
- Noticed that we need to apply different requirements based on year. 2016pre and post are the same, 2017 and 2018 are the same but different from 2016.