### PR TITLE
Handle Two Types of Event Counts

### DIFF
--- a/Framework/include/samples.h
+++ b/Framework/include/samples.h
@@ -19,19 +19,24 @@ namespace AnaSamples
    public:
     std::string tag;
     std::string filePath, fileName, treePath;
-    double xsec, kfactor, nEvts;
+    double xsec, kfactor, nGenEvts, nActEvts;
     int color;
     bool isData_;
         
     FileSummary() {}
-    FileSummary(const std::string& tag, const std::string& filePath, const std::string& fileName, const std::string& treePath, double xsec, double nEvts, double kfactor, int color = kBlack) : tag(tag), filePath(filePath), fileName(fileName), treePath(treePath), xsec(xsec), kfactor(kfactor), nEvts(nEvts), color(color), isData_(false)
+    FileSummary(const std::string& tag, const std::string& filePath, const std::string& fileName, const std::string& treePath, double xsec, double nGenEvts, double nActEvts, double kfactor, int color = kBlack) : tag(tag), filePath(filePath), fileName(fileName), treePath(treePath), xsec(xsec), kfactor(kfactor), nGenEvts(nGenEvts), nActEvts(nActEvts), color(color), isData_(false)
+    {
+      weight_ = xsec * kfactor / nGenEvts;
+    }
+
+    FileSummary(const std::string& tag, const std::string& filePath, const std::string& fileName, const std::string& treePath, double xsec, double nEvts, double kfactor, int color = kBlack) : tag(tag), filePath(filePath), fileName(fileName), treePath(treePath), xsec(xsec), kfactor(kfactor), nGenEvts(nEvts), nActEvts(nEvts), color(color), isData_(false)
     {
       weight_ = xsec * kfactor / nEvts;
     }
 
     //Constructor which doesn't make a xsec*kfactor/nEvts weighted sample, e.g. for use with data.
     //Initialize xsec, nEvts to 1 so that the comparison operators still work
-    FileSummary(const std::string& tag, const std::string& filePath, const std::string& fileName, const std::string& treePath, double kfactor, int color = kBlack) : tag(tag), filePath(filePath), fileName(fileName), treePath(treePath), xsec(1), kfactor(kfactor), nEvts(1), color(color), isData_(true)
+    FileSummary(const std::string& tag, const std::string& filePath, const std::string& fileName, const std::string& treePath, double kfactor, int color = kBlack) : tag(tag), filePath(filePath), fileName(fileName), treePath(treePath), xsec(1), kfactor(kfactor), nGenEvts(1), nActEvts(1), color(color), isData_(true)
     {
       weight_ = kfactor;
     }
@@ -148,6 +153,11 @@ namespace AnaSamples
    
    public:
     SampleSet(std::string file = "sampleSets.cfg", bool isCondor = false);
+    void addSample(const std::string& tag, const std::string& filePath, const std::string& fileName, const std::string& treePath, double xsec, double nGenEvts, double nActEvts, double kfactor, int color = kBlack) 
+    {
+        sampleSet_[tag] = FileSummary(tag, filePath, fileName, treePath, xsec, nGenEvts, nActEvts, kfactor, color);
+    }
+
     void addSample(const std::string& tag, const std::string& filePath, const std::string& fileName, const std::string& treePath, double xsec, double nEvts, double kfactor, int color = kBlack) 
     {
         sampleSet_[tag] = FileSummary(tag, filePath, fileName, treePath, xsec, nEvts, kfactor, color);

--- a/Framework/src/samples.cc
+++ b/Framework/src/samples.cc
@@ -72,16 +72,23 @@ namespace AnaSamples
     bool SampleSet::parseCfgLine(const char* buf)
     {
         char cDSname[256], cFPath[256], cfName[256], cTPath[256];
-        double f1, f2, f3, f4;
-        int nMatches = sscanf(buf, "%s %s %s %s %lf %lf %lf %lf", cDSname, cFPath, cfName, cTPath, &f1, &f2, &f3, &f4);
-        if(nMatches == 8) //this is MC 
+        double f1, f2, f3, f4, f5, f6;
+        int nMatches = sscanf(buf, "%s %s %s %s %lf %lf %lf %lf %lf %lf", cDSname, cFPath, cfName, cTPath, &f1, &f2, &f3, &f4, &f5, &f6);
+        if(nMatches == 10)
         {
-            //                                                        xsec   NEvts+ NEvts-  kfactor
-            if(!isCondor_) addSample(cDSname, cFPath, cfName, cTPath, f1,    f2 -  f3,     f4,     kGreen);
-            else           addSample(cDSname, "",     cfName, cTPath, f1,    f2 -  f3,     f4,     kGreen);
+            //                                                        xsec   NEvts+ NEvts-  NEvts+ NEvts- (skim) kfactor
+            if(!isCondor_) addSample(cDSname, cFPath, cfName, cTPath, f1,    f2  -  f3,     f4  -  f5,           f6,     kGreen);
+            else           addSample(cDSname, "",     cfName, cTPath, f1,    f2  -  f3,     f4  -  f5,           f6,     kGreen);
             return true;
         }
-        else if(nMatches == 6) //this is Data
+        else if(nMatches == 8) // contains no skimmed nEvts information
+        {
+            //                                                        xsec   NEvts+ NEvts-  kfactor
+            if(!isCondor_) addSample(cDSname, cFPath, cfName, cTPath, f1,    f2  -  f3,     f4,     kGreen);
+            else           addSample(cDSname, "",     cfName, cTPath, f1,    f2  -  f3,     f4,     kGreen);
+            return true;
+        }
+        else if(nMatches == 6) // only applicable for Data and no skim
         {
             //                                                        lumi  kfactor
             if(!isCondor_) addSample(cDSname, cFPath, cfName, cTPath, f1,   f2,     kBlack);
@@ -199,7 +206,7 @@ namespace AnaSamples
 
     bool operator== (const FileSummary& lhs, const FileSummary& rhs)
     {
-        return lhs.filePath == rhs.filePath && lhs.treePath == rhs.treePath && lhs.xsec == rhs.xsec && lhs.kfactor == rhs.kfactor && lhs.nEvts == rhs.nEvts;
+        return lhs.filePath == rhs.filePath && lhs.treePath == rhs.treePath && lhs.xsec == rhs.xsec && lhs.kfactor == rhs.kfactor && lhs.nGenEvts == rhs.nGenEvts && lhs.nActEvts == rhs.nActEvts;
     }
 
     bool operator!= (const FileSummary& lhs, const FileSummary& rhs)

--- a/Framework/src/samplesModule.cc
+++ b/Framework/src/samplesModule.cc
@@ -51,17 +51,29 @@ extern "C" {
         return array;
     }
 
-    int const * SC_samples_nEvts(AnaSamples::SampleCollection* sc, char *scn)
+    int const * SC_samples_nGenEvts(AnaSamples::SampleCollection* sc, char *scn)
     {
         auto& sampleVec = (*sc)[std::string(scn)];
         int *array = new int[sampleVec.size()];
         int i = 0;
         for(auto& sample : sampleVec)
         {
-            array[i++] = sample.nEvts;
+            array[i++] = sample.nGenEvts;
         }
         return array;
     }
+    int const * SC_samples_nActEvts(AnaSamples::SampleCollection* sc, char *scn)
+    {
+        auto& sampleVec = (*sc)[std::string(scn)];
+        int *array = new int[sampleVec.size()];
+        int i = 0;
+        for(auto& sample : sampleVec)
+        {
+            array[i++] = sample.nActEvts;
+        }
+        return array;
+    }
+
     char const ** SS_samples(AnaSamples::SampleSet* ss)
     {
         const char **array = new const char*[ss->size()];


### PR DESCRIPTION
Extend the `FileSummary` and `SampleSet` classes to handle a case where four event numbers are parsed. In this case, the first two event numbers are the *generated* positive and negative weighted event counts, while the latter two numbers are the *actual* positive and negative weighted event counts.

The event weight that is calculated inside of `FileSummary` class always uses the *generated* event counts as this corresponds to the absolute total number of events we have to work with for the sample. When running on a skimmed version of a data set, the *actual* positive and negative event counts will differ from their *generated* counter parts. These *actual* event counts correspond to the number of events actually in the skimmed data set.

The *actual* version of the event counts is used when hadding files together to verify that all events in a sample (including a skimmed sample) were run over. See the companion PR: https://github.com/StealthStop/Analyzer/pull/414