### PR TITLE
Guarantee Run of Module Path on First Event

### DIFF
--- a/Framework/include/BTagCorrector.h
+++ b/Framework/include/BTagCorrector.h
@@ -550,7 +550,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             registerVarToNTuples(tr);
     }
 

--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -526,7 +526,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             baseline(tr);
     }
 };

--- a/Framework/include/DeepEventShape.h
+++ b/Framework/include/DeepEventShape.h
@@ -434,7 +434,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             runDeepEventShape(tr);
     }
 };

--- a/Framework/include/MakeMVAVariables.h
+++ b/Framework/include/MakeMVAVariables.h
@@ -533,7 +533,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             makeMVAVariables(tr);
     }
 };

--- a/Framework/include/MakeStopHemispheres.h
+++ b/Framework/include/MakeStopHemispheres.h
@@ -237,7 +237,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             getHemispheres(tr);
     }
 };

--- a/Framework/include/RunTopTagger.h
+++ b/Framework/include/RunTopTagger.h
@@ -443,7 +443,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             runTopTagger(tr);
     }
 };

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -866,7 +866,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             scaleFactors(tr);
     }
 };

--- a/Framework/include/StopGenMatch.h
+++ b/Framework/include/StopGenMatch.h
@@ -308,7 +308,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             genMatch(tr);
     }
 };

--- a/Framework/include/StopJets.h
+++ b/Framework/include/StopJets.h
@@ -111,7 +111,7 @@ public:
         const auto& lostCauseEvent = tr.getVar<bool>("lostCauseEvent" + myVarSuffix_);
         const auto& fastMode       = tr.getVar<bool>("fastMode");
 
-        if (!lostCauseEvent or !fastMode)
+        if (!lostCauseEvent or !fastMode or tr.isFirstEvent())
             getStopJets(tr);
     }
 };


### PR DESCRIPTION
To avoid any "stale" TChain nonsense when trying to activate and access a TBranch for the first time after having moved the TTree pointer multiple times (corresponding to moving to the next file in the chain), elect to always run the full module path and activate any relevant branches on the first event, regardless of `fastMode`. This preserves the "goodness" of the pointers to the TBranches i.e. no zero values or empty vectors. No obvious solution for `NTupleReader` at this time, which is where something like this should be handled.