### PR TITLE
Support for Top Tagger SF

### DIFF
--- a/Framework/include/RunTopTagger.h
+++ b/Framework/include/RunTopTagger.h
@@ -19,7 +19,6 @@ private:
     std::vector<int>* hadtops_idx_;
     int ntops_;
     int ntops_3jet_;
-    int ntops_2jet_;
     int ntops_1jet_;
     
     inline int findParent(const int p, const int idx, const std::vector<int>& GenParticles_ParentId, const std::vector<int>& GenParticles_ParentIdx) const
@@ -113,22 +112,17 @@ private:
     {
         ntops_ = 0;
         ntops_3jet_ = 0;
-        ntops_2jet_ = 0;
         ntops_1jet_ = 0;
        
         for (const TopObject* top : tops)
         {
             ntops_++;
 
-            if(top->getNConstituents() == 3 )
+            if(top->getNConstituents())
             {
                 ntops_3jet_++;
             }
-            else if(top->getNConstituents() == 2 )
-            {
-                ntops_2jet_++;
-            }
-            else if(top->getNConstituents() == 1 )
+            else if(top->getNConstituents() == 1)
             {
                 ntops_1jet_++;
             }
@@ -150,6 +144,10 @@ private:
         // Get the top tagger results object     
         const TopTaggerResults& ttr = tt_->getResults();
        
+        // Get the working points decide if we are considering top as tagged
+        const auto& resolvedTop_WP = tr.getVar<double>("resolvedTop_WP");
+        const auto& mergedTop_WP   = tr.getVar<double>("mergedTop_WP");
+
         // Get tagged objects the new top tagger returns more than just tops now (MERGED_TOP, SEMIMERGEDWB_TOP, RESOLVED_TOP, MERGED_W, SEMIMERGEDQB_TOP)
         // For now we will only use merged and resolved tops
         const std::vector<TopObject*>& taggedObjects = ttr.getTops();
@@ -157,8 +155,8 @@ private:
         std::vector<TopObject*> resolvedTops;
         for(auto* o : taggedObjects)
         {
-            if     (o->getType()==TopObject::MERGED_TOP)   mergedTops.push_back(o);
-            else if(o->getType()==TopObject::RESOLVED_TOP) resolvedTops.push_back(o);
+            if     (o->getType()==TopObject::MERGED_TOP   and o->getDiscriminator() > mergedTop_WP)   mergedTops.push_back(o);
+            else if(o->getType()==TopObject::RESOLVED_TOP and o->getDiscriminator() > resolvedTop_WP) resolvedTops.push_back(o);
         }
 
         // --------------------------------------------------
@@ -380,7 +378,6 @@ private:
         tr.registerDerivedVar("ttr"+myVarSuffix_, &ttr);
         tr.registerDerivedVar("ntops"+myVarSuffix_, ntops_);
         tr.registerDerivedVar("ntops_3jet"+myVarSuffix_, ntops_3jet_);
-        tr.registerDerivedVar("ntops_2jet"+myVarSuffix_, ntops_2jet_);
         tr.registerDerivedVar("ntops_1jet"+myVarSuffix_, ntops_1jet_);
         tr.registerDerivedVar("dR_top1_top2"+myVarSuffix_,dR_top1_top2);
         tr.registerDerivedVar("bestTopMass"+myVarSuffix_, bestTopMass);

--- a/Framework/include/RunTopTagger.h
+++ b/Framework/include/RunTopTagger.h
@@ -118,7 +118,7 @@ private:
         {
             ntops_++;
 
-            if(top->getNConstituents())
+            if(top->getNConstituents() == 3)
             {
                 ntops_3jet_++;
             }

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -1044,17 +1044,17 @@ public:
         TString muSFHistoMediumName,      muSFHistoIsoName,         muSFHistoRecoName,          muSFHistoTrigName, nimuSFHistoTrigName;
         TString jetSFHistoTrigName_2bCut, jetSFHistoTrigName_3bCut, jetSFHistoTrigName_ge4bCut;
 
-        TString topTagSFHistoName_Res_Njet8, topTagSFHistoName_Res_Njet9incl;
-        TString topTagSFHistoName_Mrg_Njet8, topTagSFHistoName_Mrg_Njet9incl;
+        TString topTagSFHistoName_Res_Njet8,    topTagSFHistoName_Res_Njet9incl;
+        TString topTagSFHistoName_Mrg_Njet8,    topTagSFHistoName_Mrg_Njet9incl;
         TString topMistagSFHistoName_Res_Njet8, topMistagSFHistoName_Res_Njet9incl;
         TString topMistagSFHistoName_Mrg_Njet8, topMistagSFHistoName_Mrg_Njet9incl;
 
         TString topTagEffHistoName_Mrg_den = "d_eff_mrg_" + filetag;
         TString topTagEffHistoName_Res_den = "d_eff_res_" + filetag;
-        TString topTagEffHistoName_Mrg_den = "n_eff_mrg_" + filetag;
-        TString topTagEffHistoName_Res_den = "n_eff_res_" + filetag;
-        TString topTagMisHistoName_Mrg_num = "d_mis_mrg_" + filetag;
-        TString topTagMisHistoName_Res_num = "d_mis_res_" + filetag;
+        TString topTagEffHistoName_Mrg_num = "n_eff_mrg_" + filetag;
+        TString topTagEffHistoName_Res_num = "n_eff_res_" + filetag;
+        TString topTagMisHistoName_Mrg_den = "d_mis_mrg_" + filetag;
+        TString topTagMisHistoName_Res_den = "d_mis_res_" + filetag;
         TString topTagMisHistoName_Mrg_num = "n_mis_mrg_" + filetag;
         TString topTagMisHistoName_Res_num = "n_mis_res_" + filetag;
 

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -464,10 +464,8 @@ private:
         double mcTagDown = 1.0, mcNoTagDown = 1.0, dataTagDown = 1.0, dataNoTagDown = 1.0;
 
         // Distinguish if the best top candidate is resolved or merged
-        double resolvedWP = 0.95;
-        double mergedWP   = 0.937;
-        if ( runYear.find("2016") == std::string::npos )
-            mergedWP = 0.895;
+        const auto& resolvedWP = tr.getVar<double>("resolvedTop_WP");
+        const auto& mergedWP   = tr.getVar<double>("mergedTop_WP");
 
         //loop over jets
         const auto* topTagRes = tr.getVar<TopTaggerResults*>("ttr");

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -1051,10 +1051,10 @@ public:
 
         TString topTagEffHistoName_Mrg_den = "d_eff_mrg_" + filetag;
         TString topTagEffHistoName_Res_den = "d_eff_res_" + filetag;
-        TString topTagMisHistoName_Mrg_den = "n_eff_mrg_" + filetag;
-        TString topTagMisHistoName_Res_den = "n_eff_res_" + filetag;
-        TString topTagEffHistoName_Mrg_num = "d_mis_mrg_" + filetag;
-        TString topTagEffHistoName_Res_num = "d_mis_res_" + filetag;
+        TString topTagEffHistoName_Mrg_den = "n_eff_mrg_" + filetag;
+        TString topTagEffHistoName_Res_den = "n_eff_res_" + filetag;
+        TString topTagMisHistoName_Mrg_num = "d_mis_mrg_" + filetag;
+        TString topTagMisHistoName_Res_num = "d_mis_res_" + filetag;
         TString topTagMisHistoName_Mrg_num = "n_mis_mrg_" + filetag;
         TString topTagMisHistoName_Res_num = "n_mis_res_" + filetag;
 

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -33,14 +33,10 @@ private:
     std::shared_ptr<TH2F> jetSFHistoTrigName_2bCut_;
     std::shared_ptr<TH2F> jetSFHistoTrigName_3bCut_;
     std::shared_ptr<TH2F> jetSFHistoTrigName_ge4bCut_;
-    std::shared_ptr<TH1F> topTagSFHisto_Res_Njet8_;
-    std::shared_ptr<TH1F> topTagSFHisto_Res_Njet9incl_;
-    std::shared_ptr<TH1F> topTagSFHisto_Mrg_Njet8_;
-    std::shared_ptr<TH1F> topTagSFHisto_Mrg_Njet9incl_;
-    std::shared_ptr<TH1F> topMistagSFHisto_Res_Njet8_;
-    std::shared_ptr<TH1F> topMistagSFHisto_Res_Njet9incl_;
-    std::shared_ptr<TH1F> topMistagSFHisto_Mrg_Njet8_;
-    std::shared_ptr<TH1F> topMistagSFHisto_Mrg_Njet9incl_;
+    std::shared_ptr<TH1F> topTagSFHisto_Res_;
+    std::shared_ptr<TH1F> topTagSFHisto_Mrg_;
+    std::shared_ptr<TH1F> topMistagSFHisto_Res_;
+    std::shared_ptr<TH1F> topMistagSFHisto_Mrg_;
     std::shared_ptr<TH2F> topTagEffHisto_Mrg_den_;
     std::shared_ptr<TH2F> topTagEffHisto_Res_den_;
     std::shared_ptr<TH2F> topTagMisHisto_Mrg_den_;
@@ -264,25 +260,36 @@ private:
         {
             xbinJetTrig   = findBin(jetSFHistoTrigName_2bCut_, HT_trigger_pt45, "X", "jet trigger x");
             ybinJetTrig   = findBin(jetSFHistoTrigName_2bCut_, SixthJetPt45,    "Y", "jet trigger y");
-            jetTrigSF     = jetSFHistoTrigName_2bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
-            jetTrigSF_Err = jetSFHistoTrigName_2bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
+
+            if (xbinJetTrig != -1 and ybinJetTrig != -1)
+            {
+                jetTrigSF     = jetSFHistoTrigName_2bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
+                jetTrigSF_Err = jetSFHistoTrigName_2bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
+            }
         }
 
         else if (NGoodBJets_pt45 == 3)
         {
             xbinJetTrig   = findBin(jetSFHistoTrigName_3bCut_, HT_trigger_pt45, "X", "jet trigger x");
             ybinJetTrig   = findBin(jetSFHistoTrigName_3bCut_, SixthJetPt45,    "Y", "jet trigger y");
-            jetTrigSF     = jetSFHistoTrigName_3bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
-            jetTrigSF_Err = jetSFHistoTrigName_3bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
 
+            if (xbinJetTrig != -1 and ybinJetTrig != -1)
+            {
+                jetTrigSF     = jetSFHistoTrigName_3bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
+                jetTrigSF_Err = jetSFHistoTrigName_3bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
+            }
         }
 
         else if (NGoodBJets_pt45 >= 4)
         {
             xbinJetTrig   = findBin(jetSFHistoTrigName_ge4bCut_, HT_trigger_pt45, "X", "jet trigger x");
             ybinJetTrig   = findBin(jetSFHistoTrigName_ge4bCut_, SixthJetPt45,    "Y", "jet trigger y");
-            jetTrigSF     = jetSFHistoTrigName_ge4bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
-            jetTrigSF_Err = jetSFHistoTrigName_ge4bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
+
+            if (xbinJetTrig != -1 and ybinJetTrig != -1)
+            {
+                jetTrigSF     = jetSFHistoTrigName_ge4bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
+                jetTrigSF_Err = jetSFHistoTrigName_ge4bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
+            }
         }
 
         double jetTrigSF_Up   = jetTrigSF + jetTrigSF_Err;
@@ -320,8 +327,6 @@ private:
 
             if( xbinElTight != -1 && ybinElTight != -1 && xbinElIso != -1 && ybinElIso != -1 && xbinElReco != -1 && ybinElReco != -1 )
             {
-                std::cout << "WE ARE NEVE HERE" << std::endl;
-
                 const double eleTightSF    = eleSFHistoTight_->GetBinContent( xbinElTight, ybinElTight );
                 const double eleTightSFErr = eleSFHistoTight_->GetBinError( xbinElTight, ybinElTight );
                 const double eleTightPErr  = eleTightSFErr/eleTightSF;
@@ -454,8 +459,6 @@ private:
         // -------------------------------------------------------------------------------
         // Adding a top tagging scale factor in the spirit of b tag sf via "method 1a"
         // -------------------------------------------------------------------------------
-        const auto& Njets = tr.getVar<int>("NGoodJets_pt30" + myVarSuffix_);
-
         double mcTag     = 1.0, mcNoTag     = 1.0, dataTag     = 1.0, dataNoTag     = 1.0;
         double mcTagUp   = 1.0, mcNoTagUp   = 1.0, dataTagUp   = 1.0, dataNoTagUp   = 1.0;
         double mcTagDown = 1.0, mcNoTagDown = 1.0, dataTagDown = 1.0, dataNoTagDown = 1.0;
@@ -496,18 +499,9 @@ private:
                         denUnc = topTagEffHisto_Res_den_->GetBinError(xBinTopDen,   yBinTopDen);
                     }
 
-                    if      (Njets == 8)
-                    {
-                        binTopSF = findBin(topTagSFHisto_Res_Njet8_, top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topTagSFHisto_Res_Njet8_->GetBinContent(binTopSF);
-                    }
-                    else if (Njets >= 9)
-                    {
-                        binTopSF = findBin(topTagSFHisto_Res_Njet9incl_, top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topTagSFHisto_Res_Njet9incl_->GetBinContent(binTopSF);
-                    }
+                    binTopSF = findBin(topTagSFHisto_Res_, top->P().Pt(), "X", "top tag sf x");
+                    if (binTopSF != -1)
+                        sf = topTagSFHisto_Res_->GetBinContent(binTopSF);
                 }
                 else if (isMerged)
                 {
@@ -524,18 +518,9 @@ private:
                         denUnc = topTagEffHisto_Mrg_den_->GetBinError(xBinTopDen,   yBinTopDen);
                     }
 
-                    if      (Njets == 8)
-                    {
-                        binTopSF = findBin(topTagSFHisto_Mrg_Njet8_, top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topTagSFHisto_Mrg_Njet8_->GetBinContent(binTopSF);
-                    }
-                    else if (Njets >= 9)
-                    {
-                        binTopSF = findBin(topTagSFHisto_Mrg_Njet9incl_, top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topTagSFHisto_Mrg_Njet9incl_->GetBinContent(binTopSF);
-                    }
+                    binTopSF = findBin(topTagSFHisto_Mrg_, top->P().Pt(), "X", "top tag sf x");
+                    if (binTopSF != -1)
+                        sf = topTagSFHisto_Mrg_->GetBinContent(binTopSF);
                 }
             }
             // Mistag when dealing with a fake top i.e. no GEN top present
@@ -556,18 +541,9 @@ private:
                         denUnc = topTagMisHisto_Res_den_->GetBinError(xBinTopDen,   yBinTopDen);
                     }
 
-                    if      (Njets == 8)
-                    {
-                        binTopSF = findBin(topMistagSFHisto_Res_Njet8_, top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topMistagSFHisto_Res_Njet8_->GetBinContent(binTopSF);
-                    }
-                    else if (Njets >= 9)
-                    {
-                        binTopSF = findBin(topMistagSFHisto_Res_Njet9incl_, top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topMistagSFHisto_Res_Njet9incl_->GetBinContent(binTopSF);
-                    }
+                    binTopSF = findBin(topMistagSFHisto_Res_, top->P().Pt(), "X", "top tag sf x");
+                    if (binTopSF != -1)
+                        sf = topMistagSFHisto_Res_->GetBinContent(binTopSF);
                 }
                 else if (isMerged)
                 {
@@ -584,18 +560,9 @@ private:
                         denUnc = topTagMisHisto_Mrg_den_->GetBinError(xBinTopDen,   yBinTopDen);
                     }
 
-                    if      (Njets == 8)
-                    {
-                        binTopSF = findBin(topMistagSFHisto_Mrg_Njet8_,     top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topMistagSFHisto_Mrg_Njet8_->GetBinContent(binTopSF);
-                    }
-                    else if (Njets >= 9)
-                    {
-                        binTopSF = findBin(topMistagSFHisto_Mrg_Njet9incl_, top->P().Pt(), "X", "top tag sf x");
-                        if (binTopSF != -1)
-                            sf = topMistagSFHisto_Mrg_Njet9incl_->GetBinContent(binTopSF);
-                    }
+                    binTopSF = findBin(topMistagSFHisto_Mrg_,     top->P().Pt(), "X", "top tag sf x");
+                    if (binTopSF != -1)
+                        sf = topMistagSFHisto_Mrg_->GetBinContent(binTopSF);
                 }
             }
 
@@ -871,14 +838,10 @@ public:
         TFile hadronic_SFRootFile( hadronicFileName.c_str() );
         TFile toptagger_SFRootFile( toptaggerFileName.c_str() );
 
-        TString topTagSFHistoName_Res_Njet8        = runYear + "_TagRateSF_vs_topPt_Resolved_Njet8";
-        TString topTagSFHistoName_Res_Njet9incl    = runYear + "_TagRateSF_vs_topPt_Resolved_Njet9incl";
-        TString topTagSFHistoName_Mrg_Njet8        = runYear + "_TagRateSF_vs_topPt_Merged_Njet8";
-        TString topTagSFHistoName_Mrg_Njet9incl    = runYear + "_TagRateSF_vs_topPt_Merged_Njet9incl";
-        TString topMistagSFHistoName_Res_Njet8     = runYear + "_MisTagSF_vs_topPt_Resolved_Njet8";
-        TString topMistagSFHistoName_Res_Njet9incl = runYear + "_MisTagSF_vs_topPt_Resolved_Njet9incl";
-        TString topMistagSFHistoName_Mrg_Njet8     = runYear + "_MisTagSF_vs_topPt_Merged_Njet8";
-        TString topMistagSFHistoName_Mrg_Njet9incl = runYear + "_MisTagSF_vs_topPt_Merged_Njet9incl";
+        TString topTagSFHistoName_Res              = runYear + "_TagRateSF_vs_topPt_Resolved";
+        TString topTagSFHistoName_Mrg              = runYear + "_TagRateSF_vs_topPt_Merged";
+        TString topMistagSFHistoName_Res           = runYear + "_MisTagSF_vs_topPt_Resolved";
+        TString topMistagSFHistoName_Mrg           = runYear + "_MisTagSF_vs_topPt_Merged";
         TString topTagEffHistoName_Mrg_den         = "d_eff_mrg_" + filetag;
         TString topTagEffHistoName_Res_den         = "d_eff_res_" + filetag;
         TString topTagEffHistoName_Mrg_num         = "n_eff_mrg_" + filetag;
@@ -908,14 +871,10 @@ public:
         getHisto(hadronic_SFRootFile,  jetSFHistoTrigName_2bCut_,       jetSFHistoTrigName_2bCut          );
         getHisto(hadronic_SFRootFile,  jetSFHistoTrigName_3bCut_,       jetSFHistoTrigName_3bCut          );
         getHisto(hadronic_SFRootFile,  jetSFHistoTrigName_ge4bCut_,     jetSFHistoTrigName_ge4bCut        );
-        getHisto(toptagger_SFRootFile, topTagSFHisto_Res_Njet8_,        topTagSFHistoName_Res_Njet8       );
-        getHisto(toptagger_SFRootFile, topTagSFHisto_Res_Njet9incl_,    topTagSFHistoName_Res_Njet9incl   );
-        getHisto(toptagger_SFRootFile, topTagSFHisto_Mrg_Njet8_,        topTagSFHistoName_Mrg_Njet8       );
-        getHisto(toptagger_SFRootFile, topTagSFHisto_Mrg_Njet9incl_,    topTagSFHistoName_Mrg_Njet9incl   );
-        getHisto(toptagger_SFRootFile, topMistagSFHisto_Res_Njet8_,     topMistagSFHistoName_Res_Njet8    );
-        getHisto(toptagger_SFRootFile, topMistagSFHisto_Res_Njet9incl_, topMistagSFHistoName_Res_Njet9incl);
-        getHisto(toptagger_SFRootFile, topMistagSFHisto_Mrg_Njet8_,     topMistagSFHistoName_Mrg_Njet8    );
-        getHisto(toptagger_SFRootFile, topMistagSFHisto_Mrg_Njet9incl_, topMistagSFHistoName_Mrg_Njet9incl);
+        getHisto(toptagger_SFRootFile, topTagSFHisto_Res_,              topTagSFHistoName_Res             );
+        getHisto(toptagger_SFRootFile, topTagSFHisto_Mrg_,              topTagSFHistoName_Mrg             );
+        getHisto(toptagger_SFRootFile, topMistagSFHisto_Res_,           topMistagSFHistoName_Res          );
+        getHisto(toptagger_SFRootFile, topMistagSFHisto_Mrg_,           topMistagSFHistoName_Mrg          );
         getHisto(toptagger_SFRootFile, topTagEffHisto_Mrg_den_,         topTagEffHistoName_Mrg_den        );
         getHisto(toptagger_SFRootFile, topTagEffHisto_Res_den_,         topTagEffHistoName_Res_den        );
         getHisto(toptagger_SFRootFile, topTagMisHisto_Mrg_den_,         topTagMisHistoName_Mrg_den        );


### PR DESCRIPTION
Companion PR: https://github.com/StealthStop/Analyzer/pull/423

This PR adds functionality to `ScaleFactors` to calculate a final top tagger SF in the same we calculate the b tag SF.
Here we use the "method 1a" as used for the b tag SF, which incorporates efficiency and mistag rate.
The `ScaleFactors` module is now passed a top tagger histogram file that contains SF histos as well as overall efficiency and mistag rate histograms.

Attn: @semrat and @cmadrid1, if I understand how the b tag SF works, then we need to discuss how we do the same sort of thing for top tagger i.e. can we cut on the top discriminator _inside our framework_ and then count tops ? Rather than passing the working point to the top tagger module. I would like to discuss further.