### PR TITLE
updating for triggerr scale factors

### DIFF
--- a/Framework/include/Baseline.h
+++ b/Framework/include/Baseline.h
@@ -94,9 +94,9 @@ private:
         }
         
         // Blind data AND MC together, always
-        if (NGoodJets_pt30 >= 9 && blind) passBlindHad_Good  = false;
-        if (NGoodJets_pt30 >= 9 && blind) passBlindLep_Good  = false;
-        if (NGoodJets_pt30 >= 8 && blind) passBlind2Lep_Good = false;
+        if (NGoodJets_pt30 >= 10 && blind) passBlindHad_Good  = false;
+        if (NGoodJets_pt30 >= 9  && blind) passBlindLep_Good  = false;
+        if (NGoodJets_pt30 >= 8  && blind) passBlind2Lep_Good = false;
 
         // ------------------
         // MC dependent stuff

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -27,9 +27,8 @@ private:
     std::shared_ptr<TGraph> muSFHistoReco_;
     std::shared_ptr<TH2F> L1Prefireing_;
     std::map<std::string, double> sfMeanMap_;
-    std::shared_ptr<TH2F> jetSFHistoTrigName_2bCut_;
-    std::shared_ptr<TH2F> jetSFHistoTrigName_3bCut_;
-    std::shared_ptr<TH2F> jetSFHistoTrigName_ge4bCut_;
+    std::shared_ptr<TH2F> jetSFHistoTrigName_1bCut_;
+    std::shared_ptr<TH2F> jetSFHistoTrigName_ge2bCut_;
 
     template<typename T> std::shared_ptr<T>& getHisto(TFile& f, std::shared_ptr<T>& h, const TString& name)
     {
@@ -241,29 +240,20 @@ private:
       
         int xbinJetTrig  = 0,   ybinJetTrig   = 0;
         double jetTrigSF = 0.0, jetTrigSF_Err = 0.0; 
-        if (NGoodBJets_pt45 == 2)
+        if (NGoodBJets_pt45 == 1)
         {
-            xbinJetTrig   = findBin(jetSFHistoTrigName_2bCut_, HT_trigger_pt45, "X", "jet trigger x");
-            ybinJetTrig   = findBin(jetSFHistoTrigName_2bCut_, SixthJetPt45,    "Y", "jet trigger y");
-            jetTrigSF     = jetSFHistoTrigName_2bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);   
-            jetTrigSF_Err = jetSFHistoTrigName_2bCut_->GetBinError(xbinJetTrig, ybinJetTrig); 
+            xbinJetTrig   = findBin(jetSFHistoTrigName_1bCut_, HT_trigger_pt45, "X", "jet trigger x");
+            ybinJetTrig   = findBin(jetSFHistoTrigName_1bCut_, SixthJetPt45,    "Y", "jet trigger y");
+            jetTrigSF     = jetSFHistoTrigName_1bCut_->GetBinContent(xbinJetTrig, ybinJetTrig       );   
+            jetTrigSF_Err = jetSFHistoTrigName_1bCut_->GetBinError(xbinJetTrig, ybinJetTrig         ); 
         }
-       
-        else if (NGoodBJets_pt45 == 3)
-        {
-            xbinJetTrig   = findBin(jetSFHistoTrigName_3bCut_, HT_trigger_pt45, "X", "jet trigger x");
-            ybinJetTrig   = findBin(jetSFHistoTrigName_3bCut_, SixthJetPt45,    "Y", "jet trigger y");
-            jetTrigSF     = jetSFHistoTrigName_3bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
-            jetTrigSF_Err = jetSFHistoTrigName_3bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
-        
-        } 
 
-        else if (NGoodBJets_pt45 >= 4)
+        else if (NGoodBJets_pt45 >= 2)
         {
-            xbinJetTrig   = findBin(jetSFHistoTrigName_ge4bCut_, HT_trigger_pt45, "X", "jet trigger x");
-            ybinJetTrig   = findBin(jetSFHistoTrigName_ge4bCut_, SixthJetPt45,    "Y", "jet trigger y");
-            jetTrigSF     = jetSFHistoTrigName_ge4bCut_->GetBinContent(xbinJetTrig, ybinJetTrig);
-            jetTrigSF_Err = jetSFHistoTrigName_ge4bCut_->GetBinError(xbinJetTrig, ybinJetTrig);
+            xbinJetTrig   = findBin(jetSFHistoTrigName_ge2bCut_, HT_trigger_pt45, "X", "jet trigger x");
+            ybinJetTrig   = findBin(jetSFHistoTrigName_ge2bCut_, SixthJetPt45,    "Y", "jet trigger y");
+            jetTrigSF     = jetSFHistoTrigName_ge2bCut_->GetBinContent(xbinJetTrig, ybinJetTrig       );
+            jetTrigSF_Err = jetSFHistoTrigName_ge2bCut_->GetBinError(xbinJetTrig, ybinJetTrig         );
         }
 
         double jetTrigSF_Up   = jetTrigSF + jetTrigSF_Err;
@@ -660,14 +650,13 @@ public:
 
         TString eleSFHistoTightName        = "EGamma_SF2D_" + runYear + "_UL_ID";
         TString eleSFHistoRecoName         = "EGamma_SF2D_" + runYear + "_UL_RECO";
-        TString eleSFHistoTrigName         = "TrigEff_" + runYear + "_num_el_pt40_trig_5jCut_htCut_DeepCSV";
+        TString eleSFHistoTrigName         = runYear + "_el_pt40_trig_ge5jetCut_wLepPtLepEtaBin_TriggerSF";
         TString muSFHistoMediumName        = "NUM_MediumID_DEN_TrackerMuons_abseta_pt_" + runYear + "_UL_ID";
         TString muSFHistoIsoName           = "NUM_TightRelIso_DEN_MediumID_abseta_pt_" + runYear + "_UL_ISO";
-        TString muSFHistoTrigName          = "TrigEff_" + runYear + "_num_mu_pt40_trig_5jCut_htCut_DeepCSV";
+        TString muSFHistoTrigName          = runYear + "_mu_pt40_trig_ge5jetCut_wLepPtLepEtaBin_TriggerSF";
         TString nimuSFHistoTrigName        = ""; //just for calculating non iso muon scale factors
-        TString jetSFHistoTrigName_2bCut   = "h_" + runYear + "_CombHadIsoMu_trig_2bjetCut_pt45_HTvs6thJetPt_SingleMuon_TT";
-        TString jetSFHistoTrigName_3bCut   = "h_" + runYear + "_CombHadIsoMu_trig_3bjetCut_pt45_HTvs6thJetPt_SingleMuon_TT";
-        TString jetSFHistoTrigName_ge4bCut = "h_" + runYear + "_CombHadIsoMu_trig_ge4bjetCut_pt45_HTvs6thJetPt_SingleMuon_TT"; 
+        TString jetSFHistoTrigName_1bCut   = runYear + "_jet_trig_1bjetCut_wJetHt6thJetPtBin_TriggerSF";
+        TString jetSFHistoTrigName_ge2bCut = runYear + "_jet_trig_ge2bjetCut_wJetHt6thJetPtBin_TriggerSF"; 
 
         getHisto(leptonic_SFRootFile, eleSFHistoTight_,            eleSFHistoTightName       );
         getHisto(leptonic_SFRootFile, eleSFHistoReco_,             eleSFHistoRecoName        );
@@ -676,9 +665,8 @@ public:
         getHisto(leptonic_SFRootFile, muSFHistoIso_,               muSFHistoIsoName          );
         getHisto(leptonic_SFRootFile, muSFHistoTrig_,              muSFHistoTrigName         );
         getHisto(leptonic_SFRootFile, nimuSFHistoTrig_,            nimuSFHistoTrigName       );
-        getHisto(hadronic_SFRootFile, jetSFHistoTrigName_2bCut_,   jetSFHistoTrigName_2bCut  );
-        getHisto(hadronic_SFRootFile, jetSFHistoTrigName_3bCut_,   jetSFHistoTrigName_3bCut  );
-        getHisto(hadronic_SFRootFile, jetSFHistoTrigName_ge4bCut_, jetSFHistoTrigName_ge4bCut);        
+        getHisto(hadronic_SFRootFile, jetSFHistoTrigName_1bCut_,   jetSFHistoTrigName_1bCut  );
+        getHisto(hadronic_SFRootFile, jetSFHistoTrigName_ge2bCut_, jetSFHistoTrigName_ge2bCut);        
 
         leptonic_SFRootFile.Close();
         hadronic_SFRootFile.Close();        


### PR DESCRIPTION
I updated the Jet, Electron and Muon trigger SFs. because we switched to the DeepFlavor for b-tagging.

**Jet trigger SFs:**

1. I got two histograms for jet SFs: one with exactly 1b, another ≥2b
2. Also, I renamed the histograms

**Electron and Muon SFs**

1. I used the same electron and muon SFs for 1l and 2l channels.
2. Also, I renamed the histograms
