### PR TITLE
Small Updates to Framework

### DIFF
--- a/Framework/include/CommonVariables.h
+++ b/Framework/include/CommonVariables.h
@@ -295,8 +295,9 @@ private:
         tr.registerDerivedVar("singleLepton"+myVarSuffix_, singleLepton);            
 
         // 2 lepton onZ selection variables
+        // Default to clear non-physical value in case of same sign or opposite flavor leptons
         bool onZ = false;
-        double mll = 0;
+        double mll = -999.0;
         if( GoodLeptons->size() == 2 )
         {
             if( (NGoodMuons == 2 || NGoodElectrons == 2) && (GoodLeptonsCharge->at(0) != GoodLeptonsCharge->at(1)) )

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -579,7 +579,7 @@ private:
             {
                 eff     = num / den;
 
-                // Calculate uncertainty on efficiency ratio in bionomial fashion
+                // Calculate uncertainty on efficiency ratio in binomial fashion
                 // https://root.cern.ch/doc/master/TH1_8cxx_source.html#l03013
                 // When num goes to zero, eff goes to zero and effUnc as well
                 effUnc  = pow(abs(((1.0 - 2.0*eff)*pow(numUnc, 2.0) + pow(eff, 2.0)*pow(denUnc, 2.0))/pow(den, 2.0)), 0.5);

--- a/Framework/include/ScaleFactors.h
+++ b/Framework/include/ScaleFactors.h
@@ -578,7 +578,11 @@ private:
             if (den != 0.0)
             {
                 eff     = num / den;
-                effUnc  = eff * pow(pow(denUnc / den, 2) + pow(numUnc / num, 2), 0.5);
+
+                // Calculate uncertainty on efficiency ratio in bionomial fashion
+                // https://root.cern.ch/doc/master/TH1_8cxx_source.html#l03013
+                // When num goes to zero, eff goes to zero and effUnc as well
+                effUnc  = pow(abs(((1.0 - 2.0*eff)*pow(numUnc, 2.0) + pow(eff, 2.0)*pow(denUnc, 2.0))/pow(den, 2.0)), 0.5);
 
                 effUp   = eff + effUnc;
                 effDown = eff - effUnc;


### PR DESCRIPTION
`CommonVariables.h` : Default `mll` to `-999.0` so that in cases of same sign or opposite flavor, 2L events will have a more clear nonphysical value. Prevents those events from piling up in the lowest bin of an Mll plot. Only a superficial change for plotting.

`ScaleFactors.h` : Calculate uncertainty on top tagging efficiency/mistag rate a la method used when doing a binomial divide of two histograms (like how we divide histograms for trigger scale factors). The formula is taken directly from the ROOT source. This also prevents the occurrence of `NaN` up and down variations of the top tagger SF when the numerator of the efficiency/mistag rate is 0.