### PR TITLE
Flexible Tupling

### DIFF
--- a/Framework/src/MiniTupleMaker.cc
+++ b/Framework/src/MiniTupleMaker.cc
@@ -93,7 +93,12 @@ void MiniTupleMaker::fill(const NTupleReader& tr)
     // This title is unfortunately not passed on automatically when init'ing the branch
     if (!startedFilling_)
     {
-        tree_->GetBranch("TriggerPass")->SetTitle(tr.getBranchTitle("TriggerPass").c_str());
+        // Only need to rename TriggerPass branch, if we actually put it in the mini tuples
+        TBranch* trigBranch = tree_->GetBranch("TriggerPass");
+        if (trigBranch)
+        {
+            trigBranch->SetTitle(tr.getBranchTitle("TriggerPass").c_str());
+        }
         startedFilling_ = true;
     }
 }


### PR DESCRIPTION
Only try and set branch name of `TriggerPass` branch when the user is actually trying to add it to their mini tuple.